### PR TITLE
Document LXCell project foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ venv/
 **/__pycache__/
 *.DS_Store
 data/
+
+# Real personal finance workbooks are historical source material.
+# Keep them out of git; use anonymized fixtures under tests/fixtures when needed.
+*.xlsx
+*.xls
+!tests/fixtures/**/*.xlsx
+!tests/fixtures/**/*.xls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions For LXCell
+
+These instructions are for AI coding agents working in this repository. They are operational rules, not product documentation.
+
+## Must Read First
+
+Before making project changes, read:
+
+- `docs/product_requirements.md`
+- `docs/ROADMAP.md`
+- `docs/DECISIONS.md`
+
+## Hard Safety Rules
+
+- Never modify existing historical Excel workbooks in place.
+- Treat personal finance workbooks as read-only source material.
+- If workbook experimentation is required, make an explicit copy in a controlled working location.
+- Do not commit real `.xlsx` or `.xls` personal finance files.
+- Use anonymized fixtures under `tests/fixtures/` when spreadsheet test files are needed.
+- Do not remove or rewrite user-authored work unless the user explicitly asks for it.
+
+## Language Rules
+
+- Code, comments, internal identifiers, tests, and technical docs should be in English.
+- User-facing text in the application should be in Spanish.
+
+## Development Rules
+
+- Prefer small, auditable changes with tests.
+- Keep the database as the long-term source of truth.
+- Keep Excel importers read-only and validation-oriented.
+- Prefer deterministic rules before AI for transaction classification.
+- AI-generated classifications must be traceable and reviewable.
+- Ambiguous financial records should require user confirmation.
+
+## Git Context
+
+- The pre-AI-intervention code snapshot is preserved in branch `codex/pre-ai-baseline`.
+- Snapshot commit: `4787bc5` (`Preserve pre-AI intervention baseline`).
+- AI-assisted foundation work starts from branch `codex/project-foundation`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# myFinances
+# LXCell

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,55 @@
+# LXCell Decisions
+
+This file records durable project decisions so future work can recover the reasoning without relying on conversation memory.
+
+## 2026-08-05 - Product And Repository Identity
+
+Decision: use `LXCell` as the project and local repository name going forward.
+
+Reason: the GitHub repository has moved to `Huelamo/LXCell`, and the local project folder has been renamed from `myFinances` to `LXCell`. Aligning documentation with the repository name avoids confusion in future work.
+
+## 2026-08-05 - Preserve Pre-AI Code Baseline
+
+Decision: preserve the existing code before AI-assisted changes in branch `codex/pre-ai-baseline`.
+
+Reason: the project already had a working prototype and user-authored changes. Keeping a named baseline makes it easy to inspect or restore the prior state without confusing it with future "current" work.
+
+Commit: `4787bc5` (`Preserve pre-AI intervention baseline`).
+
+## 2026-08-05 - Historical Excel Files Are Read-Only
+
+Decision: existing personal finance Excel workbooks must never be modified in place.
+
+Reason: they are the user's financial history and source of truth for migration validation. Any accidental write would undermine trust in the migration.
+
+Implementation note: `.xlsx` and `.xls` files are ignored by default. If spreadsheet fixtures are needed for tests, use anonymized files under `tests/fixtures/`.
+
+## 2026-08-05 - 2026 Categories Are Canonical
+
+Decision: use the 2026 category structure as the forward-looking category model.
+
+Reason: the user has intentionally evolved categories based on what produces useful financial insight. For example, separating restaurants and leisure did not provide enough value, so the 2026 combined category is preferred.
+
+Implication: historical imports may need a category mapping layer before year-over-year comparisons.
+
+## 2026-08-05 - Auditability Over Automation
+
+Decision: prioritize traceability and reviewability over aggressive automatic classification.
+
+Reason: incorrect financial records are worse than a little extra manual review. The system should classify obvious repeated transactions automatically, but ambiguous cases should remain pending until reviewed.
+
+Implication: every imported transaction should retain source metadata, classification status, and the rule or mechanism that assigned its category.
+
+## 2026-08-05 - Database As Source Of Truth
+
+Decision: use the application database as the source of truth once migration starts. Excel files are historical import sources and may later be export targets.
+
+Reason: a normalized database scales better for transaction-level imports, multiple accounts, multiple users, deduplication, and audit trails.
+
+Current leaning: SQLite for the first serious local version because it is free, local, portable, reliable, and easy to back up. This remains open to revision if requirements outgrow it.
+
+## 2026-08-05 - Spanish UI, English Code
+
+Decision: user-facing interface text should be in Spanish; code, comments, internal names, and tests should be in English.
+
+Reason: this keeps the application comfortable for Spanish-speaking users while preserving conventional code readability.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,131 @@
+# LXCell Roadmap
+
+Last updated: 2026-08-05
+
+## Phase 0 - Project Foundation
+
+Status: in progress
+
+Goals:
+
+- Preserve the pre-AI-intervention code in a dedicated branch.
+- Record project constraints, preferences, and decisions in repo documentation.
+- Prevent accidental commits of real personal finance workbooks.
+
+## Phase 1 - Core Accounting Model
+
+Status: pending
+
+Goals:
+
+- Define normalized entities for transactions, accounts, categories, budgets, users, import batches, and classification rules.
+- Choose the local persistence layer, likely SQLite unless a better free and reliable option is justified.
+- Add tests for the core accounting behavior.
+
+Expected result:
+
+- A Python domain layer that can create, store, query, and summarize transactions independently of any GUI.
+
+## Phase 2 - Historical Excel Import
+
+Status: pending
+
+Goals:
+
+- Import existing yearly workbooks in read-only mode.
+- Convert `Registro` sheets into normalized transactions.
+- Import or reconstruct budgets from `Presupuestos`.
+- Validate imported monthly totals against `Seguimiento`.
+- Map older categories into the canonical 2026 category structure.
+
+Expected result:
+
+- A trusted historical dataset that reproduces the spreadsheet totals.
+
+## Phase 3 - Reporting Equivalent To Excel
+
+Status: pending
+
+Goals:
+
+- Recreate the useful outputs of `Seguimiento`.
+- Show budget vs actuals by month and category.
+- Track expected vs actual savings.
+- Keep reports traceable to individual transactions.
+
+Expected result:
+
+- LXCell can replace the main review workflow currently done in Excel or Google Sheets.
+
+## Phase 4 - Statement Import
+
+Status: pending
+
+Goals:
+
+- Import user-provided bank statements.
+- Start with Revolut personal and shared Revolut exports.
+- Add ING after Revolut import is stable.
+- Detect duplicate transactions across repeated imports.
+- Keep original import metadata for auditability.
+
+Expected result:
+
+- The user can import statements instead of typing transactions manually.
+
+## Phase 5 - Classification Rules
+
+Status: pending
+
+Goals:
+
+- Learn deterministic rules from historical classification patterns.
+- Auto-classify obvious recurring merchants and descriptions.
+- Mark uncertain transactions for user review.
+- Keep a record of which rule or suggestion classified each transaction.
+
+Expected result:
+
+- Most repetitive spending is categorized automatically, with review for ambiguous cases.
+
+## Phase 6 - User Interface
+
+Status: pending
+
+Goals:
+
+- Build a user-facing Spanish interface.
+- Support importing statements, reviewing classifications, editing transactions, managing budgets, and viewing dashboards.
+- Evaluate Streamlit first unless project constraints point elsewhere.
+
+Expected result:
+
+- A usable local application for day-to-day personal finance work.
+
+## Phase 7 - Multi-User Workflows
+
+Status: pending
+
+Goals:
+
+- Support separate user profiles and datasets.
+- Make it easy to manage finances for family or friends without mixing data.
+- Keep per-user categories, budgets, accounts, and import history isolated.
+
+Expected result:
+
+- The app can serve the user, family members, and interested friends safely.
+
+## Phase 8 - Agentic Assistance
+
+Status: pending
+
+Goals:
+
+- Add AI-assisted review once the data model and audit trail are reliable.
+- Suggest categories, identify anomalies, explain deviations, and prepare monthly summaries.
+- Keep human confirmation in the loop for financial records.
+
+Expected result:
+
+- LXCell becomes a review assistant, not just a register.

--- a/docs/product_requirements.md
+++ b/docs/product_requirements.md
@@ -1,0 +1,99 @@
+# LXCell Product Requirements
+
+Last updated: 2026-08-05
+
+## Purpose
+
+LXCell replaces yearly personal finance spreadsheets with a local, auditable application for transaction ingestion, categorization, budgeting, and financial review.
+
+The project starts from existing yearly Excel workbooks and a small Python prototype. The target is not a one-to-one clone of the spreadsheet layout, but a scalable system that preserves the useful accounting logic behind it.
+
+## Product Principles
+
+- Auditability has priority over maximum automation.
+- The user must be able to trace each imported transaction back to its source.
+- The system should classify obvious repeated transactions automatically.
+- Ambiguous classifications should remain pending until reviewed.
+- It is better to require more user review than to introduce many categorization errors.
+- User-facing screens, labels, messages, and reports must be in Spanish.
+
+## Users
+
+LXCell should support multiple users or profiles over time.
+
+Known use cases:
+
+- The primary user manages personal finances in yearly workbooks.
+- The primary user also prepares a finance workbook for his mother.
+- Friends and family are interested in a solution that avoids hours of manual transaction entry.
+
+Each user profile should keep categories, budgets, accounts, import history, and transaction data isolated.
+
+## Financial Scope
+
+- Primary currency: EUR.
+- Non-EUR spending occurs mainly while traveling and is paid through Revolut.
+- Priority bank sources:
+  - Revolut personal account.
+  - Shared Revolut account with Maria.
+  - ING account for lower-volume but high-impact expenses such as rent, mortgage, and utilities.
+- The 2026 category structure is canonical for future work, even if this makes year-over-year comparisons harder.
+- Earlier category structures should be mapped into the 2026 structure during migration where appropriate.
+
+## Existing Workbook Shape
+
+The user's yearly Excel workbooks generally contain:
+
+- `Registro`: manual daily transaction entry, with categories as columns.
+- `Presupuestos`: budget inputs, expected income, and savings goals.
+- `Seguimiento`: formula-driven monthly actuals vs budget tracking.
+- Additional modules such as `Hipoteca`, `Deudas`, and `Proyección inversiones`.
+
+Known issue with the spreadsheet model: using one row per day and one column per category does not scale well for many accounts, imported statements, or transaction-level audit trails.
+
+## Initial Automation Scope
+
+The first automation target is user-provided bank statement import.
+
+The system should:
+
+- Import bank statements supplied by the user.
+- Start with Revolut personal and shared Revolut exports.
+- Add ING after Revolut import is stable.
+- Detect duplicate transactions across repeated imports.
+- Keep original import metadata for auditability.
+- Learn deterministic classification rules from historical classification patterns.
+- Mark uncertain transactions for manual review.
+
+## Interface Direction
+
+Streamlit is acceptable and should be evaluated first because it can provide a useful Python-based local UI quickly.
+
+The interface should support:
+
+- Importing statements.
+- Reviewing and confirming classifications.
+- Editing transactions.
+- Managing categories and budgets.
+- Viewing monthly budget vs actuals.
+- Viewing savings and income summaries.
+
+## Data Direction
+
+The application database should become the source of truth once migration starts.
+
+Excel files should be treated as:
+
+- historical read-only import sources;
+- validation references during migration;
+- optional future export/reporting targets.
+
+Current technical leaning: SQLite for the first serious local version because it is free, local, portable, reliable, and easy to back up.
+
+## Open Product Questions
+
+- Confirm whether Streamlit remains the best UI stack after the first prototype.
+- Confirm whether SQLite is sufficient for the first production-grade local version.
+- Define the exact 2026 category list and category mapping from older workbooks.
+- Obtain anonymized sample exports for Revolut personal, Revolut shared, and ING.
+- Decide how to represent shared expenses and household accounts.


### PR DESCRIPTION
Sets up the LXCell project foundation without including legacy prototype code changes.\n\nIncludes:\n- README rename to LXCell\n- .gitignore protection for real Excel workbooks\n- AGENTS.md rules for AI coding agents\n- product requirements, roadmap, and durable decisions under docs/\n\nThis PR intentionally excludes the pre-AI baseline code snapshot, which remains preserved in codex/pre-ai-baseline.