### PR TITLE
Add confirmed historical Excel import workflow

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -273,3 +273,43 @@ Decision: add a read-only preparation step before confirmed historical Excel imp
 Reason: historical workbooks did not track the originating bank account per movement, so a technical account is more accurate than inventing provenance. Category creation from the workbook matches the expected migration path for users whose category set already lives in Excel. File-hash checks prevent accidental double import without blocking corrected workbooks whose contents have changed.
 
 Implication: the UI can now show whether an import is ready, which technical account will be used, which categories will be reused or created, and whether the file hash has already been imported. The actual database write remains deferred until the final confirmation workflow is implemented.
+
+## 2026-08-23 - Historical Excel Refund And Adjustment Semantics
+
+Decision: when historical Excel imports are confirmed into the database, expense columns with negative source amounts should become inflow transactions with `transaction_type = refund` and the original expense category. Income columns with negative source amounts are rare and should become adjustment transactions, not outflow income transactions.
+
+Reason: product returns and reimbursements reduce spending in the original expense category, while negative income represents a correction-like case that should not be mixed into ordinary income semantics.
+
+Implication: confirmed-import reporting and budget actuals should treat refunds as negative expense activity for the linked expense category.
+
+## 2026-08-23 - Phase 2 Confirmed Historical Excel Import
+
+Decision: implement confirmed historical Excel database import in `HistoricalExcelImportService`. The workflow writes from an already parsed `HistoricalExcelPreview`, requires clean `Seguimiento` validation and explicit user confirmation, creates or reuses the per-profile technical account `Excel histórico`, keeps `ImportBatch.account_id` null, reuses or creates categories from source category names, creates one transaction/source/accepted classification decision per candidate, blocks duplicate file hashes and normalized source-row overlaps, and exposes the action in the local Streamlit import tab only after preparation checks pass.
+
+Reason: the existing Phase 1 schema already supports a first auditable import without new tables. A dedicated service keeps the multi-entity workflow separate from manual entry and makes rollback behavior testable.
+
+Implication: historical Excel imports can now write confirmed transactions into the local database while preserving source-row traceability. Rollback marks the import batch as `rolled_back` and soft-deletes created transactions; it does not hard-delete audit rows or automatically deactivate categories. Persisted validation records, user-managed source category mappings, and replace/reimport workflows remain deferred.
+
+## 2026-08-23 - Per-Import Historical Category Mapping
+
+Decision: before confirmed historical Excel import, allow source categories that would otherwise be created or blocked by canonical-key conflict to be mapped to existing active LXCell categories of the same category type. The mapping choice is passed into `HistoricalExcelImportService` and is persisted as part of the confirmed file-scoped import mapping audit.
+
+Reason: older workbooks can contain categories that were later merged or removed from the canonical category model. Mapping them during import prevents obsolete categories from being recreated while preserving transaction-level traceability.
+
+Implication: multiple historical source categories can point to the same current LXCell category, and imported transactions will use that target category directly. Reusable mapping management beyond file-scoped import records remains deferred.
+
+## 2026-08-23 - File-Scoped Historical Category Mapping Records
+
+Decision: add persisted `category_mappings` for historical Excel imports, scoped by profile, source system, source file hash, and normalized source category key. Confirmed imports create mapping rows for every source category in the file, whether the category was reused, manually mapped, or newly created. The UI can suggest target categories from confirmed mappings in previous files with the same normalized source category key, but suggestions remain user-reviewed and are not applied silently.
+
+Reason: mappings need durable auditability at the file level because the same source category name may not mean exactly the same thing across different historical workbooks. Suggestions are still useful for repeated migrations, but they should assist rather than override the user's review.
+
+Implication: LXCell can now answer how each category in each imported workbook was interpreted. Multiple source categories can map to one target category. Automatic mapping application, mapping editing/superseding, and a dedicated mapping management screen remain deferred.
+
+## 2026-08-23 - Inactive Categories In Historical Imports And Transaction UI
+
+Decision: transaction tables should display inactive accounts and categories when historical transactions still reference them, labeling them as eliminated instead of showing blank category cells. Confirmed historical Excel imports should not silently reuse inactive categories by normalized name; inactive name matches should be treated as conflicts that require mapping to an active compatible category before import.
+
+Reason: inactive categories preserve historical links, but hiding them in the transaction table makes categorized transactions look uncategorized. Reusing inactive categories during new imports can also hide the fact that the user intentionally removed or merged that category.
+
+Implication: old transactions remain traceable to inactive categories, while future historical imports ask the user to resolve old category structures into the active category model.

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -644,9 +644,13 @@ Key fields:
 - `id`
 - `user_profile_id`
 - `source_system`
-- `source_year`
+- `source_file_hash`
+- `source_file_name`
 - `source_category_name`
+- `source_category_key`
+- `source_column_kind`
 - `target_category_id`
+- `created_from_import_batch_id`
 - `mapping_status`
 - `notes`
 - `created_at`
@@ -663,6 +667,12 @@ Rules:
 - The 2026 category structure should be the forward-looking target.
 - Mappings should be explicit, especially where historical category meanings changed.
 - Validation reports should show any unmapped categories.
+- Historical Excel mappings are scoped to a concrete source file hash, not
+  global by profile or year.
+- The same source category key in another workbook can be suggested from prior
+  confirmed mappings, but the user should still review it before import.
+- Multiple source categories from the same file can map to the same target
+  category.
 
 ### ExcelWorkbookImport
 
@@ -762,6 +772,7 @@ The first implementation should include:
 - `classification_decisions`
 - `budgets`
 - `budget_lines`
+- `category_mappings`
 
 Can be deferred:
 
@@ -769,13 +780,16 @@ Can be deferred:
 - `transfer_links`
 - `savings_goals`
 - `merchants`
-- `category_mappings`
 - `excel_workbook_imports`
 - `import_validation_issues`
 
 Deferring an entity should not block the schema from adding it later without rewriting transaction history.
 
-`merchants` are intentionally deferred from the first implementation schema, but they remain a planned concept for automation. Merchant normalization should be revisited before building classification automation beyond simple description-based rules.
+`category_mappings` were added during Phase 2 historical Excel import work to
+preserve file-scoped category interpretation traceability. `merchants` are
+intentionally deferred from the first implementation schema, but they remain a
+planned concept for automation. Merchant normalization should be revisited
+before building classification automation beyond simple description-based rules.
 
 ## Proposal Review Status
 
@@ -786,11 +800,11 @@ Accepted for Phase 1:
 - Represent shared accounts as `Account.ownership_type = shared`.
 - Represent manual entries through `ImportBatch.source_system = manual_entry`.
 - Do not seed real personal category sets in the public repository.
-- Defer `transaction_splits`, `transfer_links`, `savings_goals`, `merchants`, `category_mappings`, `excel_workbook_imports`, and `import_validation_issues` from the first implementation schema.
+- Defer `transaction_splits`, `transfer_links`, `savings_goals`, `merchants`, `excel_workbook_imports`, and `import_validation_issues` from the first implementation schema.
+- Add `category_mappings` during Phase 2 historical Excel import work, scoped to source file hash.
 
 Still open:
 
 - When should `merchants` be introduced to support classification automation?
-- Should category mappings be implemented during Phase 1 or as part of the historical Excel importer in Phase 2?
 - Which generic category fixtures should be used for public tests?
 - When should Alembic be introduced for schema migrations?

--- a/docs/phase_2_historical_excel_import.md
+++ b/docs/phase_2_historical_excel_import.md
@@ -15,12 +15,14 @@ Accepted blocks:
 - Block 2: local UI historical Excel preview.
 - Block 3: dry-run validation against `Seguimiento`.
 - Block 4: confirmed-import preparation screen.
+- Block 5: normalized transaction semantics for confirmed import.
+- Block 6: confirmed historical Excel database import.
+- Block 7: per-import historical category mapping.
+- Block 8: persisted file-scoped historical category mappings.
 
 Pending blocks:
 
-- Category mapping from historical source categories to current LXCell
-  categories.
-- Confirmed database import.
+- Reimport or replace workflows for corrected historical workbooks.
 
 ## Block 1 - Historical Excel Dry-Run Preview
 
@@ -221,3 +223,178 @@ Rationale:
   name/key collisions need to be visible before writing data.
 - File-hash duplicate detection prevents accidental double import while still
   allowing deliberately corrected workbooks to be treated as new source files.
+
+## Block 5 - Normalized Transaction Semantics For Confirmed Import
+
+Accepted:
+
+- Historical Excel expense columns with positive source amounts should create
+  outflow transactions with `transaction_type = expense`.
+- Historical Excel expense columns with negative source amounts should create
+  inflow transactions with `transaction_type = refund`.
+- Refunds should keep the original expense category, because they reduce prior
+  spending in that category rather than becoming income.
+- Historical Excel income columns with positive source amounts should create
+  inflow transactions with `transaction_type = income`.
+- Historical Excel income columns with negative source amounts are expected to
+  be rare. If present, they should create adjustment transactions, not outflow
+  income transactions.
+- Confirmed-import reports and budget actuals should treat refunds as negative
+  expense activity for the linked expense category.
+
+Deferred:
+
+- Any specialized UI for reviewing rare negative income adjustments before
+  import.
+
+Rationale:
+
+- Product returns and reimbursements are part of the user's normal historical
+  expense workflow, so they need explicit refund semantics.
+- Negative income should not be modeled as regular income with an inverted
+  direction, because that would make income reporting harder to understand.
+
+## Block 6 - Confirmed Historical Excel Database Import
+
+Accepted:
+
+- Add `HistoricalExcelImportService` for the confirmed write workflow rather
+  than extending the manual-entry `AccountingService`.
+- Confirmed import writes only from an already parsed `HistoricalExcelPreview`.
+  The importer still opens historical workbooks read-only.
+- Require explicit user confirmation before writing to the database.
+- Require a clean `Seguimiento` validation before writing:
+  - no differences outside tolerance;
+  - no expense categories only in `Registro`;
+  - no categories only in `Seguimiento`;
+  - at least one transaction candidate.
+- Block import if the same profile already has a completed or
+  completed-with-warnings `ImportBatch` for `source_system = excel_historical`
+  and the same `source_file_hash`.
+- Block import if candidate normalized hashes overlap with completed historical
+  source rows already stored for the same profile.
+- Block import if one source category appears with mixed income/expense column
+  semantics in the same preview.
+- Create or reuse the per-profile technical account named `Excel histórico`.
+- Keep `ImportBatch.account_id` null for historical Excel imports because the
+  batch is a mixed-account historical source.
+- Store the technical account on each created `Transaction.account_id`.
+- Reuse active categories by normalized source name.
+- Treat inactive category name matches as conflicts that must be mapped to an
+  active compatible category before import.
+- Create missing categories from source category names, with canonical keys
+  generated from those names.
+- Block canonical-key conflicts instead of guessing a mapping.
+- Create one `Transaction`, one `ImportedTransactionSource`, and one accepted
+  `ClassificationDecision` for each imported candidate.
+- Store compact source-row payload JSON and normalized source hashes for
+  traceability and duplicate detection.
+- Mark imported transactions as `review_status = user_confirmed` because the
+  confirmed workflow requires clean validation and explicit user approval.
+- Use `decision_source = historical_match` for classification decisions created
+  from historical Excel category columns.
+- Support rollback by marking the historical `ImportBatch` as `rolled_back` and
+  soft-deleting all transactions created by its source rows.
+- Do not hard-delete import batches, source rows, transactions, decisions, or
+  categories during rollback.
+- Do not automatically deactivate categories created by a rolled-back import in
+  this first workflow.
+- Expose the confirmed import action in the local Streamlit import tab only
+  after the preparation checks pass.
+
+Deferred:
+
+- Persisting aggregate validation details as dedicated audit records.
+- Replace/reimport workflows for corrected historical workbooks.
+- Specialized review UI for rare negative income adjustments.
+
+Rationale:
+
+- The existing Phase 1 schema already has enough audit tables for a first
+  reversible confirmed import, so no schema migration is needed yet.
+- Keeping the workflow service-level makes the multi-table write auditable and
+  testable without mixing import behavior into manual-entry workflows.
+- Soft rollback keeps the database explainable while allowing corrected imports
+  to be attempted later.
+
+## Block 7 - Per-Import Historical Category Mapping
+
+Accepted:
+
+- When a historical Excel source category does not match an existing LXCell
+  category by normalized name, the local UI should ask the user what to do
+  before confirmed import.
+- For each source category planned for creation, the user can either:
+  - create a new LXCell category from the source name;
+  - map the source category to an existing active LXCell category of the same
+    category type.
+- For source categories with canonical-key conflicts, the user must resolve the
+  conflict by mapping to an existing compatible active category before import.
+- Confirmed import should pass those per-import mapping choices into
+  `HistoricalExcelImportService`.
+- The service should validate mapped category IDs against the selected profile,
+  active status, and compatible category type before writing transactions.
+- Multiple historical source categories can map to the same LXCell category.
+- Mapped categories should not create new `Category` records.
+- Created transactions should point directly to the selected target category.
+- This first mapping workflow creates persisted `CategoryMapping` rows scoped to
+  the source file hash.
+
+Deferred:
+
+- Year-specific mapping review screens.
+- Applying saved mappings automatically to later historical workbooks.
+
+Rationale:
+
+- Historical category structures can differ from the current canonical category
+  model. A per-import mapping step lets the user preserve the current category
+  design without creating obsolete categories just because an old workbook used
+  them.
+- Keeping confirmed mappings scoped to the source file hash preserves strict
+  import traceability without assuming that the same category name always had
+  the same meaning in every workbook.
+
+## Block 8 - Persisted File-Scoped Historical Category Mappings
+
+Accepted:
+
+- Add `category_mappings` to the initial local schema.
+- Historical Excel mappings are scoped by:
+  - `user_profile_id`;
+  - `source_system`;
+  - `source_file_hash`;
+  - normalized `source_category_key`.
+- Store the original `source_file_name`, original `source_category_name`,
+  normalized `source_category_key`, source column kind, target LXCell category,
+  creating import batch, mapping status, notes, and timestamps.
+- Enforce uniqueness for one mapping per profile, source system, source file
+  hash, and source category key.
+- Confirmed historical imports should create one confirmed mapping per source
+  category, whether the category was reused by name, manually mapped, or newly
+  created.
+- Multiple source categories in one file may point to the same target category.
+- Imported transactions still point directly to the target category.
+- `ImportedTransactionSource` still preserves source-row details, including
+  source category in `payload_raw_json`.
+- The local UI may suggest a target category for an unresolved source category
+  by looking at confirmed mappings from previous files with the same normalized
+  source category key.
+- Suggested mappings are preselected only as user-facing assistance. They are
+  not applied silently; the confirmed import still writes mappings for the
+  current file hash.
+- Suggestions must be compatible with the source column type and target only
+  active categories of the same category type.
+
+Deferred:
+
+- Automatically applying historical mappings without user review.
+- Editing or superseding existing mapping rows.
+- A dedicated mapping management screen.
+
+Rationale:
+
+- File-scoped mappings provide precise auditability for old workbook imports:
+  the database can answer how each source category in each file was interpreted.
+- Cross-file suggestions reduce repetitive work while preserving the rule that
+  old category names may not mean the same thing in every workbook.

--- a/scripts/run_ui.sh
+++ b/scripts/run_ui.sh
@@ -17,10 +17,28 @@ export PYTHONPATH="${PROJECT_DIR}/src"
 export STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
 
 URL="http://localhost:8501"
+PORT="8501"
 
 echo "Arrancando LXCell..."
 echo "URL local: ${URL}"
 echo "Cierra esta ventana o pulsa Ctrl+C para parar la aplicación."
+
+if command -v lsof >/dev/null 2>&1; then
+  while IFS= read -r PID; do
+    [[ -z "${PID}" ]] && continue
+    PROCESS_CWD="$(lsof -a -p "${PID}" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' || true)"
+    if [[ "${PROCESS_CWD}" == "${PROJECT_DIR}" ]]; then
+      echo "Parando una instancia anterior de LXCell en el puerto ${PORT} (PID ${PID})..."
+      kill "${PID}" 2>/dev/null || true
+      sleep 1
+    else
+      echo "El puerto ${PORT} ya está en uso por otro proceso (PID ${PID})."
+      echo "Cierra ese proceso o cambia el puerto antes de arrancar LXCell."
+      read -r -p "Pulsa Enter para cerrar..."
+      exit 1
+    fi
+  done < <(lsof -tiTCP:"${PORT}" -sTCP:LISTEN 2>/dev/null || true)
+fi
 
 if command -v open >/dev/null 2>&1; then
   (sleep 3; open "${URL}" >/dev/null 2>&1 || true) &

--- a/src/lxcell/db/models.py
+++ b/src/lxcell/db/models.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from lxcell.enums.core_enums import (
     AccountType,
     BudgetPeriodType,
+    CategoryMappingStatus,
     CategoryType,
     ClassificationDecisionSource,
     ClassificationDecisionStatus,
@@ -86,6 +87,9 @@ class UserProfile(IdMixin, TimestampMixin, Base):
 
     accounts: Mapped[list["Account"]] = relationship(back_populates="user_profile")
     categories: Mapped[list["Category"]] = relationship(back_populates="user_profile")
+    category_mappings: Mapped[list["CategoryMapping"]] = relationship(
+        back_populates="user_profile", overlaps="category"
+    )
     transactions: Mapped[list["Transaction"]] = relationship(
         back_populates="user_profile", overlaps="account,category"
     )
@@ -163,6 +167,9 @@ class Category(IdMixin, TimestampMixin, Base):
         back_populates="category"
     )
     budget_lines: Mapped[list["BudgetLine"]] = relationship(back_populates="category")
+    source_category_mappings: Mapped[list["CategoryMapping"]] = relationship(
+        back_populates="target_category", overlaps="category_mappings,user_profile"
+    )
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -172,6 +179,56 @@ class Category(IdMixin, TimestampMixin, Base):
         UniqueConstraint("id", "user_profile_id"),
         UniqueConstraint("user_profile_id", "name"),
         UniqueConstraint("user_profile_id", "canonical_key"),
+    )
+
+
+class CategoryMapping(IdMixin, TimestampMixin, Base):
+    """Mapping from a historical source category to an LXCell category."""
+
+    __tablename__ = "category_mappings"
+
+    user_profile_id: Mapped[int] = mapped_column(ForeignKey("user_profiles.id"), nullable=False)
+    source_system: Mapped[ImportSourceSystem] = mapped_column(
+        enum_type(ImportSourceSystem), nullable=False
+    )
+    source_file_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    source_file_name: Mapped[str | None] = mapped_column(String(500))
+    source_category_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    source_category_key: Mapped[str] = mapped_column(String(200), nullable=False)
+    source_column_kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_category_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_from_import_batch_id: Mapped[int | None] = mapped_column(
+        ForeignKey("import_batches.id")
+    )
+    mapping_status: Mapped[CategoryMappingStatus] = mapped_column(
+        enum_type(CategoryMappingStatus),
+        default=CategoryMappingStatus.CONFIRMED,
+        nullable=False,
+    )
+    notes: Mapped[str | None] = mapped_column(Text)
+
+    user_profile: Mapped[UserProfile] = relationship(
+        back_populates="category_mappings", overlaps="target_category"
+    )
+    target_category: Mapped[Category] = relationship(
+        back_populates="source_category_mappings",
+        overlaps="category_mappings,user_profile",
+    )
+    created_from_import_batch: Mapped["ImportBatch | None"] = relationship(
+        back_populates="category_mappings"
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["target_category_id", "user_profile_id"],
+            ["categories.id", "categories.user_profile_id"],
+        ),
+        UniqueConstraint(
+            "user_profile_id",
+            "source_system",
+            "source_file_hash",
+            "source_category_key",
+        ),
     )
 
 
@@ -269,6 +326,9 @@ class ImportBatch(IdMixin, TimestampMixin, Base):
     )
     imported_transaction_sources: Mapped[list["ImportedTransactionSource"]] = relationship(
         back_populates="import_batch"
+    )
+    category_mappings: Mapped[list[CategoryMapping]] = relationship(
+        back_populates="created_from_import_batch"
     )
 
     __table_args__ = (
@@ -453,6 +513,7 @@ __all__ = [
     "Budget",
     "BudgetLine",
     "Category",
+    "CategoryMapping",
     "ClassificationDecision",
     "ClassificationRule",
     "IdMixin",

--- a/src/lxcell/enums/core_enums.py
+++ b/src/lxcell/enums/core_enums.py
@@ -98,6 +98,12 @@ class ImportAction(StrEnum):
     FAILED_VALIDATION = "failed_validation"
 
 
+class CategoryMappingStatus(StrEnum):
+    CONFIRMED = "confirmed"
+    SUGGESTED = "suggested"
+    NEEDS_REVIEW = "needs_review"
+
+
 class ClassificationRuleType(StrEnum):
     DESCRIPTION_CONTAINS = "description_contains"
     DESCRIPTION_REGEX = "description_regex"

--- a/src/lxcell/repositories/accounting_repository.py
+++ b/src/lxcell/repositories/accounting_repository.py
@@ -11,6 +11,7 @@ from lxcell.db.models import (
     Budget,
     BudgetLine,
     Category,
+    CategoryMapping,
     ClassificationDecision,
     ImportBatch,
     ImportedTransactionSource,
@@ -20,6 +21,7 @@ from lxcell.db.models import (
 from lxcell.enums.core_enums import (
     AccountType,
     BudgetPeriodType,
+    CategoryMappingStatus,
     CategoryType,
     ClassificationDecisionSource,
     ClassificationDecisionStatus,
@@ -125,6 +127,74 @@ class AccountingRepository:
         )
         self.session.add(category)
         return category
+
+    def add_category_mapping(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_file_hash: str,
+        source_category_name: str,
+        source_category_key: str,
+        source_column_kind: str,
+        target_category_id: int,
+        source_file_name: str | None = None,
+        created_from_import_batch_id: int | None = None,
+        mapping_status: CategoryMappingStatus = CategoryMappingStatus.CONFIRMED,
+        notes: str | None = None,
+    ) -> CategoryMapping:
+        category_mapping = CategoryMapping(
+            user_profile_id=user_profile_id,
+            source_system=source_system,
+            source_file_hash=source_file_hash,
+            source_file_name=source_file_name,
+            source_category_name=source_category_name,
+            source_category_key=source_category_key,
+            source_column_kind=source_column_kind,
+            target_category_id=target_category_id,
+            created_from_import_batch_id=created_from_import_batch_id,
+            mapping_status=mapping_status,
+            notes=notes,
+        )
+        self.session.add(category_mapping)
+        return category_mapping
+
+    def get_category_mapping_for_source(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_file_hash: str,
+        source_category_key: str,
+    ) -> CategoryMapping | None:
+        statement = select(CategoryMapping).where(
+            CategoryMapping.user_profile_id == user_profile_id,
+            CategoryMapping.source_system == source_system,
+            CategoryMapping.source_file_hash == source_file_hash,
+            CategoryMapping.source_category_key == source_category_key,
+        )
+        return self.session.scalar(statement)
+
+    def list_category_mapping_suggestions(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_category_key: str,
+    ) -> list[CategoryMapping]:
+        statement = (
+            select(CategoryMapping)
+            .join(Category)
+            .where(
+                CategoryMapping.user_profile_id == user_profile_id,
+                CategoryMapping.source_system == source_system,
+                CategoryMapping.source_category_key == source_category_key,
+                CategoryMapping.mapping_status == CategoryMappingStatus.CONFIRMED,
+                Category.is_active.is_(True),
+            )
+            .order_by(CategoryMapping.updated_at.desc(), CategoryMapping.id.desc())
+        )
+        return list(self.session.scalars(statement))
 
     def list_categories(
         self, user_profile_id: int, *, include_inactive: bool = False
@@ -235,6 +305,39 @@ class AccountingRepository:
         )
         return self.session.scalar(statement.order_by(ImportBatch.imported_at.desc()))
 
+    def get_import_batch(
+        self, *, import_batch_id: int, user_profile_id: int
+    ) -> ImportBatch | None:
+        statement = select(ImportBatch).where(
+            ImportBatch.id == import_batch_id,
+            ImportBatch.user_profile_id == user_profile_id,
+        )
+        return self.session.scalar(statement)
+
+    def get_imported_source_by_normalized_hash(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        normalized_hash: str,
+    ) -> ImportedTransactionSource | None:
+        statement = (
+            select(ImportedTransactionSource)
+            .join(ImportBatch)
+            .where(
+                ImportBatch.user_profile_id == user_profile_id,
+                ImportBatch.source_system == source_system,
+                ImportBatch.import_status.in_(
+                    [
+                        ImportStatus.COMPLETED,
+                        ImportStatus.COMPLETED_WITH_WARNINGS,
+                    ]
+                ),
+                ImportedTransactionSource.normalized_hash == normalized_hash,
+            )
+        )
+        return self.session.scalar(statement.order_by(ImportedTransactionSource.id))
+
     def add_imported_transaction_source(
         self,
         *,
@@ -265,6 +368,14 @@ class AccountingRepository:
         )
         self.session.add(imported_source)
         return imported_source
+
+    def list_imported_transaction_sources(
+        self, *, import_batch_id: int
+    ) -> list[ImportedTransactionSource]:
+        statement = select(ImportedTransactionSource).where(
+            ImportedTransactionSource.import_batch_id == import_batch_id
+        )
+        return list(self.session.scalars(statement.order_by(ImportedTransactionSource.id)))
 
     def get_transaction(
         self, *, transaction_id: int, user_profile_id: int

--- a/src/lxcell/services/__init__.py
+++ b/src/lxcell/services/__init__.py
@@ -1,6 +1,11 @@
 """Application services for LXCell use cases."""
 
 from lxcell.services.accounting_service import AccountingService
+from lxcell.services.historical_excel_import_service import (
+    HISTORICAL_EXCEL_ACCOUNT_NAME,
+    HistoricalExcelImportResult,
+    HistoricalExcelImportService,
+)
 from lxcell.services.reporting_service import (
     BudgetActualLine,
     BudgetActualSummary,
@@ -10,10 +15,13 @@ from lxcell.services.reporting_service import (
 )
 
 __all__ = [
+    "HISTORICAL_EXCEL_ACCOUNT_NAME",
     "AccountingService",
     "BudgetActualLine",
     "BudgetActualSummary",
     "CashflowSummary",
     "CategoryTotal",
+    "HistoricalExcelImportResult",
+    "HistoricalExcelImportService",
     "ReportingService",
 ]

--- a/src/lxcell/services/historical_excel_import_service.py
+++ b/src/lxcell/services/historical_excel_import_service.py
@@ -1,0 +1,770 @@
+"""Confirmed historical Excel import workflow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from lxcell.db.models import (
+    Account,
+    Category,
+    CategoryMapping,
+    ImportBatch,
+    ImportedTransactionSource,
+)
+from lxcell.enums.core_enums import (
+    AccountType,
+    CategoryType,
+    CategoryMappingStatus,
+    ClassificationDecisionSource,
+    ClassificationDecisionStatus,
+    Direction,
+    ImportAction,
+    ImportSourceSystem,
+    ImportStatus,
+    OwnershipType,
+    TransactionReviewStatus,
+    TransactionSourceType,
+    TransactionType,
+)
+from lxcell.importers import HistoricalExcelPreview, HistoricalExcelTransactionCandidate
+from lxcell.repositories import AccountingRepository
+
+HISTORICAL_EXCEL_ACCOUNT_NAME = "Excel histórico"
+HISTORICAL_EXCEL_DECIDED_BY_DEFAULT = "system"
+
+
+@dataclass(frozen=True)
+class HistoricalExcelImportResult:
+    """Summary of a confirmed historical Excel import."""
+
+    import_batch_id: int
+    account_id: int
+    transaction_count: int
+    created_category_count: int
+    reused_category_count: int
+    mapped_category_count: int = 0
+
+
+class HistoricalExcelImportService:
+    """Service for writing reviewed historical Excel previews to the database."""
+
+    def __init__(self, repository: AccountingRepository) -> None:
+        self.repository = repository
+
+    def confirm_import(
+        self,
+        *,
+        user_profile_id: int,
+        preview: HistoricalExcelPreview,
+        confirmed_by: str,
+        user_confirmed: bool,
+        category_id_overrides_by_source_name: dict[str, int] | None = None,
+    ) -> HistoricalExcelImportResult:
+        if not user_confirmed:
+            raise ValueError("Historical Excel import requires explicit confirmation.")
+        if not confirmed_by:
+            raise ValueError("Historical Excel import requires confirmed_by.")
+
+        blockers = historical_import_blockers(preview)
+        if blockers:
+            raise ValueError(" ".join(blockers))
+
+        duplicate_batch = self._get_completed_import_batch_by_file_hash(
+            user_profile_id=user_profile_id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_hash=preview.source_file_hash,
+        )
+        if duplicate_batch is not None:
+            raise ValueError("This historical Excel file was already imported.")
+
+        normalized_hashes = candidate_normalized_hashes(
+            user_profile_id=user_profile_id,
+            preview=preview,
+        )
+        duplicate_hashes = duplicated_values(normalized_hashes)
+        if duplicate_hashes:
+            raise ValueError(
+                "Historical Excel preview contains duplicate normalized source rows."
+            )
+        for normalized_hash in normalized_hashes.values():
+            existing_source = self._get_imported_source_by_normalized_hash(
+                user_profile_id=user_profile_id,
+                source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+                normalized_hash=normalized_hash,
+            )
+            if existing_source is not None:
+                raise ValueError(
+                    "Historical Excel import overlaps with an already imported source row."
+                )
+
+        user_profile = self.repository.get_user_profile(user_profile_id)
+        if user_profile is None:
+            raise ValueError("User profile was not found.")
+
+        account = self._get_or_create_historical_account(
+            user_profile_id=user_profile_id,
+            currency=user_profile.default_currency,
+        )
+        categories = self.repository.list_categories(user_profile_id, include_inactive=True)
+        category_plan = build_category_plan(
+            categories,
+            preview,
+            category_id_overrides_by_source_name=(
+                category_id_overrides_by_source_name or {}
+            ),
+        )
+        category_conflicts = [
+            row for row in category_plan if row.action == "conflict"
+        ]
+        if category_conflicts:
+            raise ValueError("Historical Excel import has category conflicts.")
+
+        categories_by_source_name = self._resolve_categories(
+            user_profile_id=user_profile_id,
+            category_plan=category_plan,
+        )
+        self.repository.session.flush()
+
+        import_batch = self.repository.add_import_batch(
+            user_profile_id=user_profile_id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_name=preview.source_file_name,
+            source_file_hash=preview.source_file_hash,
+            import_status=ImportStatus.PENDING,
+            imported_by=confirmed_by,
+            notes="Confirmed historical Excel import.",
+        )
+        self.repository.session.flush()
+
+        self._record_category_mappings(
+            user_profile_id=user_profile_id,
+            preview=preview,
+            import_batch=import_batch,
+            category_plan=category_plan,
+            categories_by_source_name=categories_by_source_name,
+        )
+        self.repository.session.flush()
+
+        for candidate in preview.candidates:
+            category = categories_by_source_name[candidate.source_category_name]
+            normalized_hash = normalized_hashes[candidate_key(candidate)]
+            transaction_type = transaction_type_for_candidate(candidate)
+            transaction = self.repository.add_transaction(
+                user_profile_id=user_profile_id,
+                account_id=account.id,
+                transaction_date=candidate.transaction_date,
+                description_clean=description_clean_for_candidate(candidate),
+                description_raw=candidate.description_raw,
+                category_id=category.id,
+                amount_minor=candidate.amount_minor,
+                currency=user_profile.default_currency,
+                direction=candidate.direction,
+                transaction_type=transaction_type,
+                review_status=TransactionReviewStatus.USER_CONFIRMED,
+                source_type=TransactionSourceType.EXCEL_IMPORT,
+                source_id=normalized_hash,
+            )
+            self.repository.session.flush()
+            self.repository.add_imported_transaction_source(
+                import_batch_id=import_batch.id,
+                import_action=ImportAction.CREATED_TRANSACTION,
+                row_number_source=candidate.row_number_source,
+                record_id_source=record_id_source(preview, candidate),
+                date_raw=candidate.transaction_date.isoformat(),
+                description_raw=candidate.description_raw,
+                amount_raw=candidate.amount_raw,
+                currency_raw=user_profile.default_currency,
+                payload_raw_json=payload_raw_json(preview, candidate),
+                normalized_hash=normalized_hash,
+                created_transaction_id=transaction.id,
+            )
+            self.repository.add_classification_decision(
+                transaction_id=transaction.id,
+                category_id=category.id,
+                transaction_type=transaction_type,
+                decision_source=ClassificationDecisionSource.HISTORICAL_MATCH,
+                decision_status=ClassificationDecisionStatus.ACCEPTED,
+                decided_by=confirmed_by or HISTORICAL_EXCEL_DECIDED_BY_DEFAULT,
+                notes="Historical Excel import.",
+            )
+
+        import_batch.import_status = ImportStatus.COMPLETED
+        self.repository.session.flush()
+        return HistoricalExcelImportResult(
+            import_batch_id=import_batch.id,
+            account_id=account.id,
+            transaction_count=len(preview.candidates),
+            created_category_count=sum(1 for row in category_plan if row.action == "create"),
+            reused_category_count=sum(1 for row in category_plan if row.action == "reuse"),
+            mapped_category_count=sum(1 for row in category_plan if row.action == "map"),
+        )
+
+    def _record_category_mappings(
+        self,
+        *,
+        user_profile_id: int,
+        preview: HistoricalExcelPreview,
+        import_batch: ImportBatch,
+        category_plan: list["HistoricalCategoryPlanRow"],
+        categories_by_source_name: dict[str, Category],
+    ) -> None:
+        source_column_kinds = source_category_kinds_by_name(preview)
+        for row in category_plan:
+            if row.action == "conflict":
+                continue
+            category = categories_by_source_name[row.source_category_name]
+            existing_mapping = self._get_category_mapping_for_source(
+                user_profile_id=user_profile_id,
+                source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+                source_file_hash=preview.source_file_hash,
+                source_category_key=row.source_category_key,
+            )
+            if existing_mapping is not None:
+                if existing_mapping.target_category_id != category.id:
+                    raise ValueError(
+                        "Historical Excel source category already has a different mapping."
+                    )
+                existing_mapping.created_from_import_batch_id = import_batch.id
+                continue
+            self._add_category_mapping(
+                user_profile_id=user_profile_id,
+                source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+                source_file_hash=preview.source_file_hash,
+                source_file_name=preview.source_file_name,
+                source_category_name=row.source_category_name,
+                source_category_key=row.source_category_key,
+                source_column_kind=source_column_kinds.get(
+                    row.source_category_name,
+                    "expense",
+                ),
+                target_category_id=category.id,
+                created_from_import_batch_id=import_batch.id,
+                notes=f"Created from historical Excel import action: {row.action}.",
+            )
+
+    def _add_category_mapping(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_file_hash: str,
+        source_file_name: str | None,
+        source_category_name: str,
+        source_category_key: str,
+        source_column_kind: str,
+        target_category_id: int,
+        created_from_import_batch_id: int,
+        notes: str | None = None,
+    ) -> CategoryMapping:
+        if hasattr(self.repository, "add_category_mapping"):
+            return self.repository.add_category_mapping(
+                user_profile_id=user_profile_id,
+                source_system=source_system,
+                source_file_hash=source_file_hash,
+                source_file_name=source_file_name,
+                source_category_name=source_category_name,
+                source_category_key=source_category_key,
+                source_column_kind=source_column_kind,
+                target_category_id=target_category_id,
+                created_from_import_batch_id=created_from_import_batch_id,
+                notes=notes,
+            )
+        category_mapping = CategoryMapping(
+            user_profile_id=user_profile_id,
+            source_system=source_system,
+            source_file_hash=source_file_hash,
+            source_file_name=source_file_name,
+            source_category_name=source_category_name,
+            source_category_key=source_category_key,
+            source_column_kind=source_column_kind,
+            target_category_id=target_category_id,
+            created_from_import_batch_id=created_from_import_batch_id,
+            mapping_status=CategoryMappingStatus.CONFIRMED,
+            notes=notes,
+        )
+        self.repository.session.add(category_mapping)
+        return category_mapping
+
+    def rollback_import_batch(
+        self,
+        *,
+        user_profile_id: int,
+        import_batch_id: int,
+        decided_by: str,
+    ) -> ImportBatch:
+        if not decided_by:
+            raise ValueError("Historical Excel rollback requires decided_by.")
+
+        self.repository.session.flush()
+        import_batch = self._get_import_batch(
+            import_batch_id=import_batch_id,
+            user_profile_id=user_profile_id,
+        )
+        if import_batch is None:
+            raise ValueError("Import batch was not found for the user profile.")
+        if import_batch.source_system != ImportSourceSystem.EXCEL_HISTORICAL:
+            raise ValueError("Only historical Excel import batches can be rolled back here.")
+        if import_batch.import_status == ImportStatus.ROLLED_BACK:
+            raise ValueError("Historical Excel import batch is already rolled back.")
+
+        imported_sources = self._list_imported_transaction_sources(import_batch_id)
+        for imported_source in imported_sources:
+            transaction = imported_source.created_transaction
+            if transaction is not None:
+                transaction.is_deleted = True
+
+        import_batch.import_status = ImportStatus.ROLLED_BACK
+        import_batch.notes = append_note(
+            import_batch.notes,
+            f"Rolled back by {decided_by}.",
+        )
+        return import_batch
+
+    def _get_completed_import_batch_by_file_hash(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_file_hash: str,
+    ) -> ImportBatch | None:
+        statement = select(ImportBatch).where(
+            ImportBatch.user_profile_id == user_profile_id,
+            ImportBatch.source_system == source_system,
+            ImportBatch.source_file_hash == source_file_hash,
+            ImportBatch.import_status.in_(
+                [ImportStatus.COMPLETED, ImportStatus.COMPLETED_WITH_WARNINGS]
+            ),
+        )
+        return self.repository.session.scalar(statement.order_by(ImportBatch.imported_at.desc()))
+
+    def _get_category_mapping_for_source(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        source_file_hash: str,
+        source_category_key: str,
+    ) -> CategoryMapping | None:
+        if hasattr(self.repository, "get_category_mapping_for_source"):
+            return self.repository.get_category_mapping_for_source(
+                user_profile_id=user_profile_id,
+                source_system=source_system,
+                source_file_hash=source_file_hash,
+                source_category_key=source_category_key,
+            )
+        statement = select(CategoryMapping).where(
+            CategoryMapping.user_profile_id == user_profile_id,
+            CategoryMapping.source_system == source_system,
+            CategoryMapping.source_file_hash == source_file_hash,
+            CategoryMapping.source_category_key == source_category_key,
+        )
+        return self.repository.session.scalar(statement)
+
+    def _get_imported_source_by_normalized_hash(
+        self,
+        *,
+        user_profile_id: int,
+        source_system: ImportSourceSystem,
+        normalized_hash: str,
+    ) -> ImportedTransactionSource | None:
+        statement = (
+            select(ImportedTransactionSource)
+            .join(ImportBatch)
+            .where(
+                ImportBatch.user_profile_id == user_profile_id,
+                ImportBatch.source_system == source_system,
+                ImportBatch.import_status.in_(
+                    [ImportStatus.COMPLETED, ImportStatus.COMPLETED_WITH_WARNINGS]
+                ),
+                ImportedTransactionSource.normalized_hash == normalized_hash,
+            )
+        )
+        return self.repository.session.scalar(
+            statement.order_by(ImportedTransactionSource.id)
+        )
+
+    def _get_import_batch(
+        self, *, import_batch_id: int, user_profile_id: int
+    ) -> ImportBatch | None:
+        statement = select(ImportBatch).where(
+            ImportBatch.id == import_batch_id,
+            ImportBatch.user_profile_id == user_profile_id,
+        )
+        return self.repository.session.scalar(statement)
+
+    def _list_imported_transaction_sources(
+        self, import_batch_id: int
+    ) -> list[ImportedTransactionSource]:
+        statement = select(ImportedTransactionSource).where(
+            ImportedTransactionSource.import_batch_id == import_batch_id
+        )
+        return list(self.repository.session.scalars(statement.order_by(ImportedTransactionSource.id)))
+
+    def _get_or_create_historical_account(
+        self, *, user_profile_id: int, currency: str
+    ) -> Account:
+        for account in self.repository.list_accounts(
+            user_profile_id,
+            include_inactive=True,
+        ):
+            if account.name == HISTORICAL_EXCEL_ACCOUNT_NAME:
+                return account
+        account = self.repository.add_account(
+            user_profile_id=user_profile_id,
+            name=HISTORICAL_EXCEL_ACCOUNT_NAME,
+            account_type=AccountType.OTHER,
+            currency=currency,
+            ownership_type=OwnershipType.PERSONAL,
+        )
+        self.repository.session.flush()
+        return account
+
+    def _resolve_categories(
+        self,
+        *,
+        user_profile_id: int,
+        category_plan: list["HistoricalCategoryPlanRow"],
+    ) -> dict[str, Category]:
+        categories_by_source_name: dict[str, Category] = {}
+        for row in category_plan:
+            if row.action in {"reuse", "map"}:
+                categories_by_source_name[row.source_category_name] = row.category
+                continue
+            if row.action != "create":
+                continue
+            category = self.repository.add_category(
+                user_profile_id=user_profile_id,
+                name=row.target_category_name,
+                category_type=row.category_type,
+                canonical_key=row.canonical_key,
+            )
+            categories_by_source_name[row.source_category_name] = category
+        return categories_by_source_name
+
+
+@dataclass(frozen=True)
+class HistoricalCategoryPlanRow:
+    """Internal category plan for confirmed historical imports."""
+
+    source_category_name: str
+    source_category_key: str
+    action: str
+    target_category_name: str
+    category_type: CategoryType
+    canonical_key: str
+    category: Category | None = None
+
+
+def historical_import_blockers(preview: HistoricalExcelPreview) -> list[str]:
+    validation = getattr(preview, "tracking_validation", None)
+    if validation is None:
+        return ["Historical Excel import requires comparable Seguimiento validation."]
+
+    blockers = []
+    if validation.difference_count:
+        blockers.append("Historical Excel import has Registro/Seguimiento differences.")
+    if validation.registro_only_categories:
+        blockers.append("Historical Excel import has categories only in Registro.")
+    if validation.seguimiento_only_categories:
+        blockers.append("Historical Excel import has categories only in Seguimiento.")
+    if preview.transaction_count == 0:
+        blockers.append("Historical Excel import has no transaction candidates.")
+    if mixed_source_category_kinds(preview):
+        blockers.append("Historical Excel import has mixed income/expense source categories.")
+    return blockers
+
+
+def build_category_plan(
+    categories: list[Category],
+    preview: HistoricalExcelPreview,
+    *,
+    category_id_overrides_by_source_name: dict[str, int] | None = None,
+) -> list[HistoricalCategoryPlanRow]:
+    categories_by_normalized_name = {
+        normalize_category_label(category.name): category
+        for category in categories
+    }
+    categories_by_canonical_key = {
+        category.canonical_key: category
+        for category in categories
+    }
+    categories_by_id = {category.id: category for category in categories}
+    category_overrides = category_id_overrides_by_source_name or {}
+    source_category_kinds = source_category_kinds_by_name(preview)
+
+    rows = []
+    for source_category_name in preview.source_categories:
+        normalized_name = normalize_category_label(source_category_name)
+        canonical_key = canonical_key_from_name(source_category_name)
+        category_type = category_type_from_source_kind(
+            source_category_kinds.get(source_category_name, "expense")
+        )
+        mapped_category_id = category_overrides.get(source_category_name)
+        if mapped_category_id is not None:
+            mapped_category = categories_by_id.get(mapped_category_id)
+            if mapped_category is None:
+                raise ValueError("Mapped category was not found for the user profile.")
+            if not mapped_category.is_active:
+                raise ValueError("Historical Excel import cannot map to inactive categories.")
+            if mapped_category.category_type != category_type:
+                raise ValueError(
+                    "Historical Excel import category mapping has incompatible category types."
+                )
+            rows.append(
+                HistoricalCategoryPlanRow(
+                    source_category_name=source_category_name,
+                    source_category_key=normalized_name,
+                    action="map",
+                    target_category_name=mapped_category.name,
+                    category_type=mapped_category.category_type,
+                    canonical_key=mapped_category.canonical_key,
+                    category=mapped_category,
+                )
+            )
+            continue
+
+        matched_category = categories_by_normalized_name.get(normalized_name)
+        if matched_category is not None and matched_category.is_active:
+            rows.append(
+                HistoricalCategoryPlanRow(
+                    source_category_name=source_category_name,
+                    source_category_key=normalized_name,
+                    action="reuse",
+                    target_category_name=matched_category.name,
+                    category_type=matched_category.category_type,
+                    canonical_key=matched_category.canonical_key,
+                    category=matched_category,
+                )
+            )
+            continue
+        if matched_category is not None and not matched_category.is_active:
+            rows.append(
+                HistoricalCategoryPlanRow(
+                    source_category_name=source_category_name,
+                    source_category_key=normalized_name,
+                    action="conflict",
+                    target_category_name=matched_category.name,
+                    category_type=matched_category.category_type,
+                    canonical_key=matched_category.canonical_key,
+                    category=matched_category,
+                )
+            )
+            continue
+
+        conflicting_category = categories_by_canonical_key.get(canonical_key)
+        if conflicting_category is not None:
+            rows.append(
+                HistoricalCategoryPlanRow(
+                    source_category_name=source_category_name,
+                    source_category_key=normalized_name,
+                    action="conflict",
+                    target_category_name=conflicting_category.name,
+                    category_type=conflicting_category.category_type,
+                    canonical_key=canonical_key,
+                    category=conflicting_category,
+                )
+            )
+            continue
+
+        rows.append(
+            HistoricalCategoryPlanRow(
+                source_category_name=source_category_name,
+                source_category_key=normalized_name,
+                action="create",
+                target_category_name=source_category_name,
+                category_type=category_type,
+                canonical_key=canonical_key,
+            )
+        )
+    return rows
+
+
+def source_category_kinds_by_name(preview: HistoricalExcelPreview) -> dict[str, str]:
+    kinds_by_name: dict[str, str] = {}
+    for candidate in preview.candidates:
+        category_name = candidate.source_category_name
+        category_kind = candidate_source_column_kind(candidate)
+        if category_kind == "income":
+            kinds_by_name[category_name] = "income"
+        else:
+            kinds_by_name.setdefault(category_name, "expense")
+    return kinds_by_name
+
+
+def mixed_source_category_kinds(preview: HistoricalExcelPreview) -> set[str]:
+    kinds_by_name: dict[str, set[str]] = {}
+    for candidate in preview.candidates:
+        kinds_by_name.setdefault(candidate.source_category_name, set()).add(
+            candidate_source_column_kind(candidate)
+        )
+    return {
+        category_name
+        for category_name, kinds in kinds_by_name.items()
+        if len(kinds) > 1
+    }
+
+
+def category_type_from_source_kind(source_kind: str) -> CategoryType:
+    if source_kind == "income":
+        return CategoryType.INCOME
+    return CategoryType.EXPENSE
+
+
+def transaction_type_for_candidate(
+    candidate: HistoricalExcelTransactionCandidate,
+) -> TransactionType:
+    source_kind = candidate_source_column_kind(candidate)
+    source_amount = candidate_source_amount_decimal(candidate)
+    if source_kind == "income":
+        if source_amount < 0:
+            return TransactionType.ADJUSTMENT
+        return TransactionType.INCOME
+    if source_amount < 0:
+        return TransactionType.REFUND
+    return TransactionType.EXPENSE
+
+
+def description_clean_for_candidate(
+    candidate: HistoricalExcelTransactionCandidate,
+) -> str:
+    if candidate.description_raw and candidate.description_raw.strip():
+        return candidate.description_raw.strip()
+    return f"Excel histórico: {candidate.source_category_name}"
+
+
+def candidate_normalized_hashes(
+    *,
+    user_profile_id: int,
+    preview: HistoricalExcelPreview,
+) -> dict[tuple[int, str], str]:
+    return {
+        candidate_key(candidate): normalized_hash_for_candidate(
+            user_profile_id=user_profile_id,
+            candidate=candidate,
+        )
+        for candidate in preview.candidates
+    }
+
+
+def normalized_hash_for_candidate(
+    *,
+    user_profile_id: int,
+    candidate: HistoricalExcelTransactionCandidate,
+) -> str:
+    parts = [
+        str(user_profile_id),
+        candidate.transaction_date.isoformat(),
+        normalize_category_label(candidate.source_category_name),
+        str(candidate.amount_minor),
+        candidate.direction.value,
+        normalize_category_label(candidate.description_raw or ""),
+        candidate_source_column_kind(candidate),
+        str(candidate_source_signed_amount_minor(candidate)),
+    ]
+    digest = hashlib.sha256()
+    digest.update("|".join(parts).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def duplicated_values(values_by_key: dict[tuple[int, str], str]) -> set[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values_by_key.values():
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return duplicates
+
+
+def candidate_key(candidate: HistoricalExcelTransactionCandidate) -> tuple[int, str]:
+    return candidate.row_number_source, candidate.source_category_name
+
+
+def record_id_source(
+    preview: HistoricalExcelPreview,
+    candidate: HistoricalExcelTransactionCandidate,
+) -> str:
+    return (
+        f"{preview.sheet_name}:"
+        f"{candidate.row_number_source}:"
+        f"{candidate.column_name_source}"
+    )
+
+
+def payload_raw_json(
+    preview: HistoricalExcelPreview,
+    candidate: HistoricalExcelTransactionCandidate,
+) -> str:
+    payload = {
+        "sheet_name": preview.sheet_name,
+        "source_category_name": candidate.source_category_name,
+        "source_column_kind": candidate_source_column_kind(candidate),
+        "row": candidate.payload_raw,
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def append_note(existing_notes: str | None, note: str) -> str:
+    if not existing_notes:
+        return note
+    return f"{existing_notes}\n{note}"
+
+
+def candidate_source_column_kind(candidate) -> str:
+    return getattr(candidate, "source_column_kind", "expense")
+
+
+def candidate_source_amount_decimal(candidate) -> Decimal:
+    source_amount_decimal = getattr(candidate, "source_amount_decimal", None)
+    if source_amount_decimal is not None:
+        return source_amount_decimal
+    source_amount_minor = getattr(candidate, "source_amount_minor", None)
+    if source_amount_minor is not None:
+        return Decimal(source_amount_minor) / Decimal("100")
+    amount = Decimal(candidate.amount_minor) / Decimal("100")
+    if candidate_source_column_kind(candidate) == "income":
+        return amount if candidate.direction == Direction.INFLOW else -amount
+    return amount if candidate.direction == Direction.OUTFLOW else -amount
+
+
+def candidate_source_signed_amount_minor(candidate) -> int:
+    source_amount_minor = getattr(candidate, "source_amount_minor", None)
+    if source_amount_minor is not None:
+        return int(source_amount_minor)
+    return int(candidate_source_amount_decimal(candidate) * Decimal("100"))
+
+
+def canonical_key_from_name(name: str) -> str:
+    normalized = unicodedata.normalize("NFKD", name)
+    ascii_name = normalized.encode("ascii", "ignore").decode("ascii")
+    canonical_key = re.sub(r"[^a-zA-Z0-9]+", "_", ascii_name).strip("_").lower()
+    if not canonical_key:
+        raise ValueError("Category name must produce a canonical key.")
+    return canonical_key
+
+
+def normalize_category_label(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value.strip().lower())
+    without_accents = "".join(
+        character
+        for character in normalized
+        if not unicodedata.combining(character)
+    )
+    return " ".join(without_accents.split())
+
+
+__all__ = [
+    "HISTORICAL_EXCEL_ACCOUNT_NAME",
+    "HistoricalExcelImportResult",
+    "HistoricalExcelImportService",
+    "build_category_plan",
+    "historical_import_blockers",
+    "transaction_type_for_candidate",
+]

--- a/src/lxcell/ui/streamlit_app.py
+++ b/src/lxcell/ui/streamlit_app.py
@@ -16,7 +16,7 @@ import streamlit as st
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from lxcell.db.models import Category, ImportBatch, Transaction
+from lxcell.db.models import Category, CategoryMapping, ImportBatch, Transaction
 from lxcell.db.runtime import DEFAULT_DATABASE_PATH, create_local_session_factory
 from lxcell.db.session import session_scope
 from lxcell.enums.core_enums import (
@@ -32,6 +32,7 @@ from lxcell.enums.core_enums import (
 from lxcell.importers import HistoricalExcelPreview
 from lxcell.repositories import AccountingRepository
 from lxcell.services import AccountingService
+from lxcell.services.historical_excel_import_service import HistoricalExcelImportService
 
 PENDING_DUPLICATE_TRANSACTION_KEY = "lxcell_pending_duplicate_transaction"
 HISTORICAL_EXCEL_PREVIEW_KEY = "lxcell_historical_excel_preview"
@@ -254,14 +255,26 @@ def render_transactions(session_factory, selected_profile_id: int | None) -> Non
         return
 
     render_flash_success("transactions")
-    accounts, categories = load_accounting_lists(session_factory, selected_profile_id)
-    account_labels = {account.id: account.name for account in accounts}
-    category_labels = {None: "Sin categoría"} | {
-        category.id: category.name for category in categories
+    accounts, categories = load_accounting_lists(
+        session_factory,
+        selected_profile_id,
+        include_inactive=True,
+    )
+    account_labels = {
+        account.id: account_label_for_transaction_table(account)
+        for account in accounts
     }
-    account_ids_by_label = {account.name: account.id for account in accounts}
+    category_labels = {None: "Sin categoría"} | {
+        category.id: category_label_for_transaction_table(category)
+        for category in categories
+    }
+    account_ids_by_label = {
+        account_label_for_transaction_table(account): account.id
+        for account in accounts
+    }
     category_ids_by_label = {"Sin categoría": None} | {
-        category.name: category.id for category in categories
+        category_label_for_transaction_table(category): category.id
+        for category in categories
     }
 
     with session_scope(session_factory) as session:
@@ -461,6 +474,7 @@ def render_import_preview(session_factory, selected_profile_id: int | None) -> N
         return
 
     st.subheader("Importar Excel histórico")
+    render_flash_success("historical_import")
     uploaded_file = st.file_uploader("Archivo .xlsx", type=["xlsx"])
     sheet_name = st.text_input("Hoja", value="Registro")
 
@@ -630,13 +644,31 @@ def render_historical_import_preparation(
         include_inactive=True,
     )
     category_plan = historical_category_import_plan(categories, preview)
+    category_mapping_suggestions = historical_category_mapping_suggestions(
+        session_factory,
+        user_profile_id=selected_profile_id,
+        category_plan=category_plan,
+    )
+    category_mapping_overrides = render_historical_category_mapping_controls(
+        categories,
+        category_plan,
+        category_mapping_suggestions,
+    )
+    resolved_category_plan = apply_historical_category_mapping_to_plan(
+        category_plan,
+        categories,
+        category_mapping_overrides,
+    )
     category_conflicts = [
-        row for row in category_plan if row["acción"] == "conflicto"
+        row for row in resolved_category_plan if row["acción"] == "conflicto"
     ]
 
     transaction_column, category_column, account_column = st.columns(3)
     transaction_column.metric("Transacciones", preview.transaction_count)
-    category_column.metric("Categorías nuevas", count_rows_by_action(category_plan, "crear"))
+    category_column.metric(
+        "Categorías nuevas",
+        count_rows_by_action(resolved_category_plan, "crear"),
+    )
     account_column.metric("Cuenta destino", HISTORICAL_EXCEL_ACCOUNT_NAME)
 
     if validation_blockers:
@@ -647,8 +679,8 @@ def render_historical_import_preparation(
     if category_conflicts:
         st.warning("Hay conflictos de categorías que requieren revisión.")
 
-    if category_plan:
-        st.dataframe(pd.DataFrame(category_plan), use_container_width=True)
+    if resolved_category_plan:
+        st.dataframe(pd.DataFrame(resolved_category_plan), use_container_width=True)
 
     can_prepare_import = (
         not validation_blockers
@@ -657,11 +689,35 @@ def render_historical_import_preparation(
         and preview.transaction_count > 0
     )
     if can_prepare_import:
-        st.checkbox(
-            "Confirmo que quiero preparar la importación de este Excel histórico",
-            key="confirm_historical_excel_import_preparation",
+        confirmed_by = st.text_input("Confirmado por", value="local_ui")
+        user_confirmed = st.checkbox(
+            "Confirmo que quiero importar este Excel histórico en la base de datos",
+            key="confirm_historical_excel_import",
         )
-        st.success("La importación está lista para el paso de escritura en base de datos.")
+        if st.button(
+            "Importar Excel histórico",
+            type="primary",
+            disabled=not user_confirmed,
+        ):
+            try:
+                result = confirm_historical_excel_import_from_preview(
+                    session_factory,
+                    user_profile_id=selected_profile_id,
+                    preview=preview,
+                    confirmed_by=confirmed_by.strip(),
+                    user_confirmed=user_confirmed,
+                    category_id_overrides_by_source_name=category_mapping_overrides,
+                )
+            except (IntegrityError, ValueError) as exc:
+                st.error(str(exc))
+                return
+            st.session_state.pop(HISTORICAL_EXCEL_PREVIEW_KEY, None)
+            flash_success(
+                "historical_import",
+                "Importación completada: "
+                f"{result.transaction_count} transacciones.",
+            )
+            st.rerun()
 
 
 def historical_import_validation_blockers(preview: HistoricalExcelPreview) -> list[str]:
@@ -687,12 +743,6 @@ def completed_historical_import_batch(
 ):
     with session_scope(session_factory) as session:
         repository = AccountingRepository(session)
-        if hasattr(repository, "get_completed_import_batch_by_file_hash"):
-            return repository.get_completed_import_batch_by_file_hash(
-                user_profile_id=user_profile_id,
-                source_system=ImportSourceSystem.EXCEL_HISTORICAL,
-                source_file_hash=source_file_hash,
-            )
         return completed_historical_import_batch_fallback(
             repository,
             user_profile_id=user_profile_id,
@@ -715,6 +765,188 @@ def completed_historical_import_batch_fallback(
         ),
     )
     return repository.session.scalar(statement.order_by(ImportBatch.imported_at.desc()))
+
+
+def confirm_historical_excel_import_from_preview(
+    session_factory,
+    *,
+    user_profile_id: int,
+    preview: HistoricalExcelPreview,
+    confirmed_by: str,
+    user_confirmed: bool,
+    category_id_overrides_by_source_name: dict[str, int] | None = None,
+):
+    with session_scope(session_factory) as session:
+        service = HistoricalExcelImportService(AccountingRepository(session))
+        result = service.confirm_import(
+            user_profile_id=user_profile_id,
+            preview=preview,
+            confirmed_by=confirmed_by,
+            user_confirmed=user_confirmed,
+            category_id_overrides_by_source_name=(
+                category_id_overrides_by_source_name
+            ),
+        )
+        session.flush()
+        return result
+
+
+def render_historical_category_mapping_controls(
+    categories,
+    category_plan: list[dict],
+    category_mapping_suggestions: dict[str, int] | None = None,
+) -> dict[str, int]:
+    rows_to_resolve = [
+        row for row in category_plan if row["acción"] in {"crear", "conflicto"}
+    ]
+    if not rows_to_resolve:
+        return {}
+
+    st.subheader("Resolver categorías")
+    category_id_overrides = {}
+    active_categories = [category for category in categories if category.is_active]
+    for row in rows_to_resolve:
+        compatible_categories = [
+            category
+            for category in active_categories
+            if category.category_type.value == row["tipo"]
+        ]
+        suggested_category_id = (category_mapping_suggestions or {}).get(
+            row["categoría Excel"]
+        )
+        selected_category_id = historical_category_mapping_selectbox(
+            row,
+            compatible_categories,
+            suggested_category_id=suggested_category_id,
+        )
+        if selected_category_id is not None:
+            category_id_overrides[row["categoría Excel"]] = selected_category_id
+    return category_id_overrides
+
+
+def historical_category_mapping_selectbox(
+    row: dict,
+    compatible_categories,
+    *,
+    suggested_category_id: int | None = None,
+) -> int | None:
+    create_option = "__create__"
+    select_option = "__select__"
+    options = [category.id for category in compatible_categories]
+    if row["acción"] == "crear":
+        options = [create_option] + options
+    else:
+        options = [select_option] + options
+
+    labels = {
+        create_option: f"Crear nueva categoría '{row['categoría Excel']}'",
+        select_option: "Selecciona una categoría existente",
+    } | {category.id: category.name for category in compatible_categories}
+    if suggested_category_id in {category.id for category in compatible_categories}:
+        st.caption(f"Sugerencia: {labels[suggested_category_id]}")
+    index = (
+        options.index(suggested_category_id)
+        if suggested_category_id in options
+        else 0
+    )
+    selected_value = st.selectbox(
+        f"Categoría destino para {row['categoría Excel']}",
+        options=options,
+        format_func=labels.get,
+        index=index,
+        key=f"historical_category_mapping_{row['categoría Excel']}",
+    )
+    return selected_value if isinstance(selected_value, int) else None
+
+
+def historical_category_mapping_suggestions(
+    session_factory,
+    *,
+    user_profile_id: int,
+    category_plan: list[dict],
+) -> dict[str, int]:
+    rows_to_resolve = [
+        row for row in category_plan if row["acción"] in {"crear", "conflicto"}
+    ]
+    if not rows_to_resolve:
+        return {}
+
+    suggestions = {}
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        for row in rows_to_resolve:
+            source_category_key = normalize_category_label_for_import(
+                row["categoría Excel"]
+            )
+            if hasattr(repository, "list_category_mapping_suggestions"):
+                mapping_suggestions = repository.list_category_mapping_suggestions(
+                    user_profile_id=user_profile_id,
+                    source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+                    source_category_key=source_category_key,
+                )
+            else:
+                mapping_suggestions = historical_category_mapping_suggestions_fallback(
+                    repository,
+                    user_profile_id=user_profile_id,
+                    source_category_key=source_category_key,
+                )
+            compatible_mapping = next(
+                (
+                    mapping
+                    for mapping in mapping_suggestions
+                    if mapping.target_category.is_active
+                    and mapping.target_category.category_type.value == row["tipo"]
+                ),
+                None,
+            )
+            if compatible_mapping is not None:
+                suggestions[row["categoría Excel"]] = compatible_mapping.target_category_id
+    return suggestions
+
+
+def historical_category_mapping_suggestions_fallback(
+    repository: AccountingRepository,
+    *,
+    user_profile_id: int,
+    source_category_key: str,
+):
+    statement = (
+        select(CategoryMapping)
+        .join(Category)
+        .where(
+            CategoryMapping.user_profile_id == user_profile_id,
+            CategoryMapping.source_system == ImportSourceSystem.EXCEL_HISTORICAL,
+            CategoryMapping.source_category_key == source_category_key,
+            Category.is_active.is_(True),
+        )
+        .order_by(CategoryMapping.updated_at.desc(), CategoryMapping.id.desc())
+    )
+    return list(repository.session.scalars(statement))
+
+
+def apply_historical_category_mapping_to_plan(
+    category_plan: list[dict],
+    categories,
+    category_id_overrides_by_source_name: dict[str, int],
+) -> list[dict]:
+    categories_by_id = {category.id: category for category in categories}
+    resolved_rows = []
+    for row in category_plan:
+        category_id = category_id_overrides_by_source_name.get(row["categoría Excel"])
+        if category_id is None:
+            resolved_rows.append(row)
+            continue
+        category = categories_by_id[category_id]
+        resolved_rows.append(
+            {
+                "categoría Excel": row["categoría Excel"],
+                "acción": "mapear",
+                "categoría LXCell": category.name,
+                "tipo": category.category_type.value,
+                "clave": category.canonical_key,
+            }
+        )
+    return resolved_rows
 
 
 def historical_category_import_plan(categories, preview: HistoricalExcelPreview) -> list[dict]:
@@ -740,12 +972,25 @@ def historical_category_import_plan(categories, preview: HistoricalExcelPreview)
         )
 
         matched_category = categories_by_normalized_name.get(normalized_name)
-        if matched_category is not None:
+        if matched_category is not None and matched_category.is_active:
             rows.append(
                 {
                     "categoría Excel": source_category_name,
                     "acción": "reutilizar",
                     "categoría LXCell": matched_category.name,
+                    "tipo": matched_category.category_type.value,
+                    "clave": matched_category.canonical_key,
+                }
+            )
+            continue
+        if matched_category is not None and not matched_category.is_active:
+            rows.append(
+                {
+                    "categoría Excel": source_category_name,
+                    "acción": "conflicto",
+                    "categoría LXCell": category_label_for_transaction_table(
+                        matched_category
+                    ),
                     "tipo": matched_category.category_type.value,
                     "clave": matched_category.canonical_key,
                 }
@@ -1139,6 +1384,18 @@ def transaction_table_rows(
         }
         for transaction in transactions
     ]
+
+
+def account_label_for_transaction_table(account) -> str:
+    if account.is_active:
+        return account.name
+    return f"{account.name} (eliminada)"
+
+
+def category_label_for_transaction_table(category) -> str:
+    if category.is_active:
+        return category.name
+    return f"{category.name} (eliminada)"
 
 
 def apply_transaction_table_changes(

--- a/tests/test_accounting_repository.py
+++ b/tests/test_accounting_repository.py
@@ -8,6 +8,7 @@ from lxcell.db.session import create_session_factory, create_sqlite_engine, sess
 from lxcell.enums.core_enums import (
     AccountType,
     BudgetPeriodType,
+    CategoryMappingStatus,
     CategoryType,
     ClassificationDecisionSource,
     ClassificationDecisionStatus,
@@ -280,6 +281,57 @@ def test_repository_finds_completed_import_batch_by_hash(session_factory):
 
     assert found_batch.id == completed_batch.id
     assert pending_batch is None
+
+
+def test_repository_creates_file_scoped_category_mapping_and_suggestions(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        user_profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        target_category = repository.add_category(
+            user_profile_id=user_profile.id,
+            name="Combined Category",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="combined_category",
+        )
+        batch = repository.add_import_batch(
+            user_profile_id=user_profile.id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_hash="abc123",
+            import_status=ImportStatus.COMPLETED,
+        )
+        session.flush()
+        mapping = repository.add_category_mapping(
+            user_profile_id=user_profile.id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_hash="abc123",
+            source_file_name="sample.xlsx",
+            source_category_name="Legacy Category",
+            source_category_key="legacy category",
+            source_column_kind="expense",
+            target_category_id=target_category.id,
+            created_from_import_batch_id=batch.id,
+        )
+
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        stored_mapping = repository.get_category_mapping_for_source(
+            user_profile_id=user_profile.id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_hash="abc123",
+            source_category_key="legacy category",
+        )
+        suggestions = repository.list_category_mapping_suggestions(
+            user_profile_id=user_profile.id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_category_key="legacy category",
+        )
+
+    assert stored_mapping.id == mapping.id
+    assert stored_mapping.mapping_status == CategoryMappingStatus.CONFIRMED
+    assert [suggestion.id for suggestion in suggestions] == [mapping.id]
 
 
 def test_repository_lists_classification_decisions_through_profile_scope(

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -45,6 +45,7 @@ def test_phase_1_models_configure_and_create_expected_tables(session_factory):
         "budget_lines",
         "budgets",
         "categories",
+        "category_mappings",
         "classification_decisions",
         "classification_rules",
         "import_batches",

--- a/tests/test_historical_excel_import_service.py
+++ b/tests/test_historical_excel_import_service.py
@@ -1,0 +1,514 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, select
+
+from lxcell.db.models import (
+    Account,
+    Base,
+    Category,
+    CategoryMapping,
+    ClassificationDecision,
+    ImportBatch,
+    ImportedTransactionSource,
+    Transaction,
+)
+from lxcell.db.session import create_session_factory, create_sqlite_engine, session_scope
+from lxcell.enums.core_enums import (
+    AccountType,
+    CategoryType,
+    ClassificationDecisionSource,
+    ClassificationDecisionStatus,
+    Direction,
+    ImportSourceSystem,
+    ImportStatus,
+    TransactionReviewStatus,
+    TransactionSourceType,
+    TransactionType,
+)
+from lxcell.importers import (
+    HistoricalExcelPreview,
+    HistoricalExcelTrackingComparison,
+    HistoricalExcelTrackingValidation,
+    HistoricalExcelTransactionCandidate,
+)
+from lxcell.repositories import AccountingRepository
+from lxcell.services import AccountingService, HistoricalExcelImportService
+from lxcell.services.historical_excel_import_service import (
+    HISTORICAL_EXCEL_ACCOUNT_NAME,
+)
+
+
+@pytest.fixture()
+def session_factory(tmp_path):
+    engine = create_sqlite_engine(f"sqlite:///{tmp_path / 'lxcell.db'}")
+    Base.metadata.create_all(engine)
+    return create_session_factory(engine)
+
+
+def test_confirmed_historical_excel_import_writes_auditable_records(session_factory):
+    with session_scope(session_factory) as session:
+        service = AccountingService(AccountingRepository(session))
+        profile = service.create_user_profile(display_name="Sample User")
+        session.flush()
+        existing_category = service.create_category(
+            user_profile_id=profile.id,
+            name="Category A",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="category_a",
+        )
+        session.flush()
+
+        result = HistoricalExcelImportService(
+            AccountingRepository(session)
+        ).confirm_import(
+            user_profile_id=profile.id,
+            preview=sample_preview(),
+            confirmed_by="Sample User",
+            user_confirmed=True,
+        )
+        session.flush()
+
+    with session_scope(session_factory) as session:
+        transactions = list(session.scalars(select(Transaction).order_by(Transaction.id)))
+        import_batch = session.scalar(select(ImportBatch))
+        account = session.scalar(select(Account))
+        categories = list(session.scalars(select(Category).order_by(Category.name)))
+        imported_sources = list(
+            session.scalars(select(ImportedTransactionSource).order_by(ImportedTransactionSource.id))
+        )
+        decisions = list(
+            session.scalars(select(ClassificationDecision).order_by(ClassificationDecision.id))
+        )
+
+    assert result.transaction_count == 4
+    assert result.created_category_count == 1
+    assert result.reused_category_count == 1
+    assert account.name == HISTORICAL_EXCEL_ACCOUNT_NAME
+    assert account.account_type == AccountType.OTHER
+    assert import_batch.account_id is None
+    assert import_batch.source_system == ImportSourceSystem.EXCEL_HISTORICAL
+    assert import_batch.source_file_hash == "abc123"
+    assert import_batch.import_status == ImportStatus.COMPLETED
+    assert [category.name for category in categories] == ["Category A", "Income A"]
+    assert categories[0].id == existing_category.id
+    assert categories[1].category_type == CategoryType.INCOME
+    assert len(imported_sources) == 4
+    assert all(source.normalized_hash for source in imported_sources)
+    assert [transaction.review_status for transaction in transactions] == [
+        TransactionReviewStatus.USER_CONFIRMED,
+    ] * 4
+    assert [transaction.source_type for transaction in transactions] == [
+        TransactionSourceType.EXCEL_IMPORT,
+    ] * 4
+    assert [transaction.transaction_type for transaction in transactions] == [
+        TransactionType.EXPENSE,
+        TransactionType.REFUND,
+        TransactionType.INCOME,
+        TransactionType.ADJUSTMENT,
+    ]
+    assert [transaction.direction for transaction in transactions] == [
+        Direction.OUTFLOW,
+        Direction.INFLOW,
+        Direction.INFLOW,
+        Direction.OUTFLOW,
+    ]
+    assert [decision.decision_source for decision in decisions] == [
+        ClassificationDecisionSource.HISTORICAL_MATCH,
+    ] * 4
+    assert [decision.decision_status for decision in decisions] == [
+        ClassificationDecisionStatus.ACCEPTED,
+    ] * 4
+    assert {decision.decided_by for decision in decisions} == {"Sample User"}
+
+
+def test_confirmed_historical_excel_import_requires_explicit_confirmation(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        profile = AccountingRepository(session).add_user_profile(display_name="Sample User")
+        session.flush()
+
+        with pytest.raises(ValueError, match="explicit confirmation"):
+            HistoricalExcelImportService(AccountingRepository(session)).confirm_import(
+                user_profile_id=profile.id,
+                preview=sample_preview(),
+                confirmed_by="Sample User",
+                user_confirmed=False,
+            )
+
+    with session_scope(session_factory) as session:
+        assert session.scalar(select(func.count(ImportBatch.id))) == 0
+
+
+def test_confirmed_historical_excel_import_maps_source_categories_to_existing_category(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        service = AccountingService(AccountingRepository(session))
+        profile = service.create_user_profile(display_name="Sample User")
+        session.flush()
+        combined_category = service.create_category(
+            user_profile_id=profile.id,
+            name="Combined Category",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="combined_category",
+        )
+        session.flush()
+
+        result = HistoricalExcelImportService(
+            AccountingRepository(session)
+        ).confirm_import(
+            user_profile_id=profile.id,
+            preview=mapping_preview(),
+            confirmed_by="Sample User",
+            user_confirmed=True,
+            category_id_overrides_by_source_name={
+                "Legacy Category A": combined_category.id,
+                "Legacy Category B": combined_category.id,
+            },
+        )
+
+    with session_scope(session_factory) as session:
+        categories = list(session.scalars(select(Category)))
+        mappings = list(
+            session.scalars(select(CategoryMapping).order_by(CategoryMapping.source_category_name))
+        )
+        transactions = list(session.scalars(select(Transaction).order_by(Transaction.id)))
+
+    assert result.created_category_count == 0
+    assert result.mapped_category_count == 2
+    assert len(categories) == 1
+    assert [
+        (mapping.source_file_hash, mapping.source_category_name, mapping.target_category_id)
+        for mapping in mappings
+    ] == [
+        ("legacy123", "Legacy Category A", combined_category.id),
+        ("legacy123", "Legacy Category B", combined_category.id),
+    ]
+    assert {transaction.category_id for transaction in transactions} == {
+        combined_category.id
+    }
+
+
+def test_confirmed_historical_excel_import_rejects_incompatible_category_mapping(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        service = AccountingService(AccountingRepository(session))
+        profile = service.create_user_profile(display_name="Sample User")
+        session.flush()
+        income_category = service.create_category(
+            user_profile_id=profile.id,
+            name="Income Category",
+            category_type=CategoryType.INCOME,
+            canonical_key="income_category",
+        )
+        session.flush()
+
+        with pytest.raises(ValueError, match="incompatible category types"):
+            HistoricalExcelImportService(AccountingRepository(session)).confirm_import(
+                user_profile_id=profile.id,
+                preview=mapping_preview(),
+                confirmed_by="Sample User",
+                user_confirmed=True,
+                category_id_overrides_by_source_name={
+                    "Legacy Category A": income_category.id,
+                },
+            )
+
+
+def test_confirmed_historical_excel_import_does_not_silently_reuse_inactive_category(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        service = AccountingService(AccountingRepository(session))
+        profile = service.create_user_profile(display_name="Sample User")
+        session.flush()
+        service.create_category(
+            user_profile_id=profile.id,
+            name="Legacy Category A",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="legacy_category_a",
+        )
+        session.flush()
+        inactive_category = AccountingRepository(session).list_categories(
+            profile.id,
+            include_inactive=True,
+        )[0]
+        inactive_category.is_active = False
+
+        with pytest.raises(ValueError, match="category conflicts"):
+            HistoricalExcelImportService(AccountingRepository(session)).confirm_import(
+                user_profile_id=profile.id,
+                preview=mapping_preview(),
+                confirmed_by="Sample User",
+                user_confirmed=True,
+            )
+
+
+def test_confirmed_historical_excel_import_blocks_dirty_validation(session_factory):
+    with session_scope(session_factory) as session:
+        profile = AccountingRepository(session).add_user_profile(display_name="Sample User")
+        session.flush()
+
+        with pytest.raises(ValueError, match="differences"):
+            HistoricalExcelImportService(AccountingRepository(session)).confirm_import(
+                user_profile_id=profile.id,
+                preview=sample_preview(
+                    tracking_validation=HistoricalExcelTrackingValidation(
+                        sheet_name="Seguimiento",
+                        comparisons=(
+                            HistoricalExcelTrackingComparison(
+                                month_key="2026-01",
+                                source_category_name="Category A",
+                                registro_amount_minor=750,
+                                seguimiento_amount_minor=748,
+                            ),
+                        ),
+                        registro_only_categories=(),
+                        seguimiento_only_categories=(),
+                    )
+                ),
+                confirmed_by="Sample User",
+                user_confirmed=True,
+            )
+
+    with session_scope(session_factory) as session:
+        assert session.scalar(select(func.count(ImportBatch.id))) == 0
+
+
+def test_confirmed_historical_excel_import_blocks_same_file_hash_per_profile(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        first_profile = repository.add_user_profile(display_name="Sample User")
+        second_profile = repository.add_user_profile(display_name="Other Sample User")
+        session.flush()
+
+        service = HistoricalExcelImportService(repository)
+        service.confirm_import(
+            user_profile_id=first_profile.id,
+            preview=sample_preview(),
+            confirmed_by="Sample User",
+            user_confirmed=True,
+        )
+        with pytest.raises(ValueError, match="already imported"):
+            service.confirm_import(
+                user_profile_id=first_profile.id,
+                preview=sample_preview(),
+                confirmed_by="Sample User",
+                user_confirmed=True,
+            )
+        second_result = service.confirm_import(
+            user_profile_id=second_profile.id,
+            preview=sample_preview(),
+            confirmed_by="Other Sample User",
+            user_confirmed=True,
+        )
+
+    assert second_result.transaction_count == 4
+
+
+def test_confirmed_historical_excel_import_blocks_normalized_row_overlap(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+
+        service = HistoricalExcelImportService(repository)
+        service.confirm_import(
+            user_profile_id=profile.id,
+            preview=sample_preview(source_file_hash="abc123"),
+            confirmed_by="Sample User",
+            user_confirmed=True,
+        )
+        with pytest.raises(ValueError, match="overlaps"):
+            service.confirm_import(
+                user_profile_id=profile.id,
+                preview=sample_preview(source_file_hash="def456"),
+                confirmed_by="Sample User",
+                user_confirmed=True,
+            )
+
+
+def test_historical_excel_import_rollback_soft_deletes_created_transactions(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        service = HistoricalExcelImportService(repository)
+        result = service.confirm_import(
+            user_profile_id=profile.id,
+            preview=sample_preview(),
+            confirmed_by="Sample User",
+            user_confirmed=True,
+        )
+        service.rollback_import_batch(
+            user_profile_id=profile.id,
+            import_batch_id=result.import_batch_id,
+            decided_by="Sample User",
+        )
+
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        transactions = list(session.scalars(select(Transaction).order_by(Transaction.id)))
+        import_batch = repository.get_import_batch(
+            import_batch_id=result.import_batch_id,
+            user_profile_id=profile.id,
+        )
+        duplicate_batch = repository.get_completed_import_batch_by_file_hash(
+            user_profile_id=profile.id,
+            source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+            source_file_hash="abc123",
+        )
+
+    assert import_batch.import_status == ImportStatus.ROLLED_BACK
+    assert all(transaction.is_deleted for transaction in transactions)
+    assert duplicate_batch is None
+
+
+def sample_preview(
+    *,
+    source_file_hash: str = "abc123",
+    tracking_validation: HistoricalExcelTrackingValidation | None = None,
+) -> HistoricalExcelPreview:
+    return HistoricalExcelPreview(
+        source_file_name="sample.xlsx",
+        source_file_hash=source_file_hash,
+        sheet_name="Registro",
+        header_row_number=2,
+        date_column_name="Fecha",
+        candidates=(
+            candidate(
+                row_number_source=3,
+                source_category_name="Category A",
+                amount=Decimal("10.00"),
+                direction=Direction.OUTFLOW,
+                source_column_kind="expense",
+                description_raw="Merchant A",
+            ),
+            candidate(
+                row_number_source=4,
+                source_category_name="Category A",
+                amount=Decimal("-2.50"),
+                direction=Direction.INFLOW,
+                source_column_kind="expense",
+                description_raw="Merchant A refund",
+            ),
+            candidate(
+                row_number_source=5,
+                source_category_name="Income A",
+                amount=Decimal("20.00"),
+                direction=Direction.INFLOW,
+                source_column_kind="income",
+                description_raw="Income Source A",
+            ),
+            candidate(
+                row_number_source=6,
+                source_category_name="Income A",
+                amount=Decimal("-1.00"),
+                direction=Direction.OUTFLOW,
+                source_column_kind="income",
+                description_raw="Income adjustment A",
+            ),
+        ),
+        ignored_row_numbers=(),
+        tracking_validation=tracking_validation
+        or HistoricalExcelTrackingValidation(
+            sheet_name="Seguimiento",
+            comparisons=(
+                HistoricalExcelTrackingComparison(
+                    month_key="2026-01",
+                    source_category_name="Category A",
+                    registro_amount_minor=750,
+                    seguimiento_amount_minor=750,
+                ),
+            ),
+            registro_only_categories=(),
+            seguimiento_only_categories=(),
+        ),
+    )
+
+
+def mapping_preview() -> HistoricalExcelPreview:
+    return HistoricalExcelPreview(
+        source_file_name="legacy_sample.xlsx",
+        source_file_hash="legacy123",
+        sheet_name="Registro",
+        header_row_number=2,
+        date_column_name="Fecha",
+        candidates=(
+            candidate(
+                row_number_source=3,
+                source_category_name="Legacy Category A",
+                amount=Decimal("10.00"),
+                direction=Direction.OUTFLOW,
+                source_column_kind="expense",
+                description_raw="Merchant A",
+            ),
+            candidate(
+                row_number_source=4,
+                source_category_name="Legacy Category B",
+                amount=Decimal("5.00"),
+                direction=Direction.OUTFLOW,
+                source_column_kind="expense",
+                description_raw="Merchant B",
+            ),
+        ),
+        ignored_row_numbers=(),
+        tracking_validation=HistoricalExcelTrackingValidation(
+            sheet_name="Seguimiento",
+            comparisons=(
+                HistoricalExcelTrackingComparison(
+                    month_key="2026-01",
+                    source_category_name="Legacy Category A",
+                    registro_amount_minor=1000,
+                    seguimiento_amount_minor=1000,
+                ),
+                HistoricalExcelTrackingComparison(
+                    month_key="2026-01",
+                    source_category_name="Legacy Category B",
+                    registro_amount_minor=500,
+                    seguimiento_amount_minor=500,
+                ),
+            ),
+            registro_only_categories=(),
+            seguimiento_only_categories=(),
+        ),
+    )
+
+
+def candidate(
+    *,
+    row_number_source: int,
+    source_category_name: str,
+    amount: Decimal,
+    direction: Direction,
+    source_column_kind: str,
+    description_raw: str,
+) -> HistoricalExcelTransactionCandidate:
+    return HistoricalExcelTransactionCandidate(
+        row_number_source=row_number_source,
+        column_name_source=source_category_name,
+        transaction_date=date(2026, 1, 10),
+        source_category_name=source_category_name,
+        amount_minor=abs(int(amount * Decimal("100"))),
+        direction=direction,
+        amount_raw=str(amount),
+        description_raw=description_raw,
+        payload_raw={
+            "Fecha": "2026-01-10",
+            source_category_name: str(amount),
+            "Comentarios": description_raw,
+        },
+        source_amount_minor=int(amount * Decimal("100")),
+        source_amount_decimal=amount,
+        source_column_kind=source_column_kind,
+    )

--- a/tests/test_streamlit_ui.py
+++ b/tests/test_streamlit_ui.py
@@ -2,9 +2,10 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from lxcell.db.models import Base
+from lxcell.db.models import Base, CategoryMapping, ImportBatch
 from lxcell.db.session import create_session_factory, create_sqlite_engine, session_scope
 from lxcell.enums.core_enums import (
     AccountType,
@@ -24,9 +25,13 @@ from lxcell.repositories import AccountingRepository
 from lxcell.services import AccountingService
 from lxcell.ui.streamlit_app import (
     HISTORICAL_EXCEL_PREVIEW_VERSION,
+    account_label_for_transaction_table,
+    apply_historical_category_mapping_to_plan,
     canonical_key_from_name,
+    category_label_for_transaction_table,
     category_table_rows,
     category_table_success_message,
+    confirm_historical_excel_import_from_preview,
     completed_historical_import_batch_fallback,
     edited_category_payload,
     edited_transaction_payload,
@@ -35,6 +40,7 @@ from lxcell.ui.streamlit_app import (
     friendly_integrity_error_message,
     historical_preview_can_render,
     historical_category_import_plan,
+    historical_category_mapping_suggestions,
     historical_import_validation_blockers,
     manual_transaction_payload,
     normalize_category_label_for_import,
@@ -209,6 +215,29 @@ def test_category_table_rows_show_deleted_status_in_advanced_view(session_factor
             "clave": "category_a",
         }
     ]
+
+
+def test_transaction_table_labels_show_inactive_records(session_factory):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        account = repository.add_account(
+            user_profile_id=profile.id,
+            name="Historical account",
+            account_type=AccountType.OTHER,
+            is_active=False,
+        )
+        category = repository.add_category(
+            user_profile_id=profile.id,
+            name="Category A",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="category_a",
+            is_active=False,
+        )
+
+    assert account_label_for_transaction_table(account) == "Historical account (eliminada)"
+    assert category_label_for_transaction_table(category) == "Category A (eliminada)"
 
 
 def test_update_category_for_ui_falls_back_for_loaded_legacy_service(session_factory):
@@ -628,6 +657,140 @@ def test_historical_category_import_plan_reuses_creates_and_flags_conflicts(
     ]
 
 
+def test_historical_category_import_plan_flags_inactive_name_match_as_conflict(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        inactive_category = repository.add_category(
+            user_profile_id=profile.id,
+            name="Category A",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="category_a",
+            is_active=False,
+        )
+
+    preview = HistoricalExcelPreview(
+        source_file_name="sample.xlsx",
+        source_file_hash="abc123",
+        sheet_name="Registro",
+        header_row_number=2,
+        date_column_name="Fecha",
+        candidates=(
+            HistoricalExcelTransactionCandidate(
+                row_number_source=3,
+                column_name_source="Category A",
+                transaction_date=date(2026, 1, 10),
+                source_category_name="Category A",
+                amount_minor=100,
+                direction=Direction.OUTFLOW,
+                amount_raw="1",
+                description_raw=None,
+                payload_raw={},
+                source_column_kind="expense",
+            ),
+        ),
+        ignored_row_numbers=(),
+    )
+
+    rows = historical_category_import_plan([inactive_category], preview)
+
+    assert rows == [
+        {
+            "categoría Excel": "Category A",
+            "acción": "conflicto",
+            "categoría LXCell": "Category A (eliminada)",
+            "tipo": "expense",
+            "clave": "category_a",
+        }
+    ]
+
+
+def test_apply_historical_category_mapping_to_plan_marks_selected_existing_category(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        target_category = repository.add_category(
+            user_profile_id=profile.id,
+            name="Combined Category",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="combined_category",
+        )
+
+    rows = apply_historical_category_mapping_to_plan(
+        [
+            {
+                "categoría Excel": "Legacy Category A",
+                "acción": "crear",
+                "categoría LXCell": "Legacy Category A",
+                "tipo": "expense",
+                "clave": "legacy_category_a",
+            },
+        ],
+        [target_category],
+        {"Legacy Category A": target_category.id},
+    )
+
+    assert rows == [
+        {
+            "categoría Excel": "Legacy Category A",
+            "acción": "mapear",
+            "categoría LXCell": "Combined Category",
+            "tipo": "expense",
+            "clave": "combined_category",
+        }
+    ]
+
+
+def test_historical_category_mapping_suggestions_use_prior_confirmed_mapping(
+    session_factory,
+):
+    with session_scope(session_factory) as session:
+        repository = AccountingRepository(session)
+        profile = repository.add_user_profile(display_name="Sample User")
+        session.flush()
+        target_category = repository.add_category(
+            user_profile_id=profile.id,
+            name="Combined Category",
+            category_type=CategoryType.EXPENSE,
+            canonical_key="combined_category",
+        )
+        session.flush()
+        session.add(
+            CategoryMapping(
+                user_profile_id=profile.id,
+                source_system=ImportSourceSystem.EXCEL_HISTORICAL,
+                source_file_hash="older_hash",
+                source_file_name="older.xlsx",
+                source_category_name="Legacy Category A",
+                source_category_key="legacy category a",
+                source_column_kind="expense",
+                target_category_id=target_category.id,
+            )
+        )
+
+    suggestions = historical_category_mapping_suggestions(
+        session_factory,
+        user_profile_id=profile.id,
+        category_plan=[
+            {
+                "categoría Excel": "Legacy Category A",
+                "acción": "crear",
+                "categoría LXCell": "Legacy Category A",
+                "tipo": "expense",
+                "clave": "legacy_category_a",
+            }
+        ],
+    )
+
+    assert suggestions == {"Legacy Category A": target_category.id}
+
+
 def test_historical_import_validation_blockers_require_clean_tracking_validation():
     invalid_preview = HistoricalExcelPreview(
         source_file_name="sample.xlsx",
@@ -680,6 +843,64 @@ def test_completed_historical_import_batch_fallback_finds_completed_hash(
         )
 
     assert found_batch.id == batch.id
+
+
+def test_confirm_historical_excel_import_from_preview_writes_import(session_factory):
+    with session_scope(session_factory) as session:
+        profile = AccountingRepository(session).add_user_profile(display_name="Sample User")
+        session.flush()
+
+    preview = HistoricalExcelPreview(
+        source_file_name="sample.xlsx",
+        source_file_hash="abc123",
+        sheet_name="Registro",
+        header_row_number=2,
+        date_column_name="Fecha",
+        candidates=(
+            HistoricalExcelTransactionCandidate(
+                row_number_source=3,
+                column_name_source="Category A",
+                transaction_date=date(2026, 1, 10),
+                source_category_name="Category A",
+                amount_minor=100,
+                direction=Direction.OUTFLOW,
+                amount_raw="1",
+                description_raw=None,
+                payload_raw={},
+                source_amount_minor=100,
+                source_amount_decimal=Decimal("1.00"),
+                source_column_kind="expense",
+            ),
+        ),
+        ignored_row_numbers=(),
+        tracking_validation=HistoricalExcelTrackingValidation(
+            sheet_name="Seguimiento",
+            comparisons=(
+                HistoricalExcelTrackingComparison(
+                    month_key="2026-01",
+                    source_category_name="Category A",
+                    registro_amount_minor=100,
+                    seguimiento_amount_minor=100,
+                ),
+            ),
+            registro_only_categories=(),
+            seguimiento_only_categories=(),
+        ),
+    )
+
+    result = confirm_historical_excel_import_from_preview(
+        session_factory,
+        user_profile_id=profile.id,
+        preview=preview,
+        confirmed_by="Sample User",
+        user_confirmed=True,
+    )
+
+    with session_scope(session_factory) as session:
+        import_batch = session.scalar(select(ImportBatch))
+
+    assert result.transaction_count == 1
+    assert import_batch.source_file_hash == "abc123"
 
 
 def test_normalize_category_label_for_import_is_accent_insensitive():


### PR DESCRIPTION
## Summary
- add confirmed historical Excel import service with audit source rows, classification decisions, rollback, duplicate checks, and file-scoped category mappings
- expose confirmed import and historical category mapping/suggestions in the Streamlit UI
- document the accepted import, refund/adjustment, mapping, and inactive-category decisions

## Tests
- PYTHONPATH=src .venv/bin/pytest